### PR TITLE
Fix Keycloak token expiration handling

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -76,10 +76,24 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
                 const { authenticated, keycloak } = await initKeycloak();
                 if (authenticated && keycloak.token) {
                     await saveToken(keycloak.token);
+                } else {
+                    await saveToken(null);
                 }
 
                 keycloak.onAuthSuccess = () => {
                     saveToken(keycloak.token);
+                };
+
+                keycloak.onTokenExpired = () => {
+                    keycloak.updateToken(0).then((refreshed: boolean) => {
+                        if (refreshed) {
+                            saveToken(keycloak.token);
+                        } else {
+                            logout();
+                        }
+                    }).catch(() => {
+                        logout();
+                    });
                 };
 
                 console.log('Keycloak authenticated:', authenticated);


### PR DESCRIPTION
## Summary
- handle expired sessions by clearing saved token
- refresh token when Keycloak reports expiration

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68470fa9fd28832c99641334aaf24ad6