### PR TITLE
Add listening transcript generation UI for homework composer

### DIFF
--- a/src/components/homework/HomeworkComposerDrawer.tsx
+++ b/src/components/homework/HomeworkComposerDrawer.tsx
@@ -72,14 +72,14 @@ const HomeworkComposerDrawer: React.FC<HomeworkComposerDrawerProps> = ({ open, o
   const [selectedStudent, setSelectedStudent] = React.useState<{ id: string; name: string; email?: string; avatar?: string } | null>(null);
   const [studentLoading, setStudentLoading] = React.useState(false);
 
-  const [title, setTitle] = React.useState('Homework');
+  const [title, setTitle] = React.useState('Homework-' + new Date().toISOString().slice(0, 10));
   const [instructions, setInstructions] = React.useState('');
   const [dueAt, setDueAt] = React.useState('');
 
   // Task fields
   const [taskTitle, setTaskTitle] = React.useState('Task 1');
-  const [taskType, setTaskType] = React.useState<HomeworkTaskType>('VIDEO');
-  const [sourceKind, setSourceKind] = React.useState<SourceKind>('EXTERNAL_URL');
+  const [taskType, setTaskType] = React.useState<HomeworkTaskType>('VOCAB');
+  const [sourceKind, setSourceKind] = React.useState<SourceKind>('VOCAB_LIST');
   const [sourceUrl, setSourceUrl] = React.useState('');
 
   // VOCAB_LIST selection & settings
@@ -113,7 +113,7 @@ const HomeworkComposerDrawer: React.FC<HomeworkComposerDrawerProps> = ({ open, o
   const [transcriptInfo, setTranscriptInfo] = React.useState<string | null>(null);
   const [hasUnsavedTranscriptEdits, setHasUnsavedTranscriptEdits] = React.useState(false);
 
-  const isVocabList = taskType === 'VOCAB' && sourceKind === 'VOCAB_LIST';
+  const isVocabList = taskType === 'VOCAB';
   const isListeningTask = taskType === 'LISTENING';
 
   // Load vocabulary words
@@ -145,9 +145,9 @@ const HomeworkComposerDrawer: React.FC<HomeworkComposerDrawerProps> = ({ open, o
   const listeningWordRequirementMet = listeningWordIds.length >= 3;
 
   const cefrOptions = React.useMemo(() => Array.from(new Set(Object.values(ENGLISH_LEVELS).map(level => level.code))), []);
-  const languageOptions = React.useMemo(() => ['en-US', 'en-GB', 'en-AU', 'es-ES', 'fr-FR', 'de-DE'], []);
+  const languageOptions = React.useMemo(() => ['en-US', 'en-GB'], []);
   const styleOptions = React.useMemo(() => ['neutral', 'storytelling', 'documentary', 'conversational', 'inspirational'], []);
-  const taskTypeOptions: HomeworkTaskType[] = ['VIDEO', 'READING', 'GRAMMAR', 'VOCAB', 'LISTENING', 'LINK'];
+  const taskTypeOptions: HomeworkTaskType[] = [/*'VIDEO', 'READING', 'GRAMMAR' 'LINK',*/ 'VOCAB', 'LISTENING', ];
   const durationMarks = React.useMemo(() => (
     [
       { value: 45, label: '0:45' },
@@ -156,7 +156,7 @@ const HomeworkComposerDrawer: React.FC<HomeworkComposerDrawerProps> = ({ open, o
       { value: 120, label: '2:00' },
     ]
   ), []);
-  const sourceKindOptions: SourceKind[] = ['MATERIAL', 'LESSON_CONTENT', 'EXTERNAL_URL', 'VOCAB_LIST', 'GENERATED_AUDIO'];
+  const sourceKindOptions: SourceKind[] = [/*'MATERIAL', 'LESSON_CONTENT', 'EXTERNAL_URL',*/ 'VOCAB_LIST', 'GENERATED_AUDIO'];
 
   const formatDurationLabel = (value: number) => {
     const mins = Math.floor(value / 60);
@@ -364,6 +364,8 @@ const HomeworkComposerDrawer: React.FC<HomeworkComposerDrawerProps> = ({ open, o
       setSourceKind('GENERATED_AUDIO');
     } else if (sourceKind === 'GENERATED_AUDIO') {
       setSourceKind('EXTERNAL_URL');
+    } else if (isVocabList){
+        setSourceKind('VOCAB_LIST');
     }
   }, [isListeningTask, sourceKind]);
 
@@ -720,7 +722,7 @@ const HomeworkComposerDrawer: React.FC<HomeworkComposerDrawerProps> = ({ open, o
               >
                 {taskTypeOptions.map(t => (<MenuItem key={t} value={t}>{t}</MenuItem>))}
               </TextField>
-              {!isListeningTask ? (
+              {!isListeningTask && !isVocabList ? (
                 <TextField
                   select
                   label="Source kind"
@@ -728,12 +730,14 @@ const HomeworkComposerDrawer: React.FC<HomeworkComposerDrawerProps> = ({ open, o
                   onChange={e => setSourceKind(e.target.value as SourceKind)}
                 >
                   {sourceKindOptions
-                    .filter(s => s !== 'GENERATED_AUDIO')
+                    .filter(s => s !== 'GENERATED_AUDIO' && s !== 'VOCAB_LIST')
                     .map(s => (<MenuItem key={s} value={s}>{s}</MenuItem>))}
                 </TextField>
-              ) : (
+              ) : ( isListeningTask ? (
                 <TextField label="Source kind" value="GENERATED_AUDIO" InputProps={{ readOnly: true }} disabled />
-              )}
+              ) : (
+                      <TextField label="Source kind" value="VOCAB_LIST" InputProps={{ readOnly: true }} disabled />
+                  ))}
 
               {sourceKind === 'EXTERNAL_URL' && (
                 <Stack direction="row" gap={1} alignItems="center">
@@ -816,7 +820,7 @@ const HomeworkComposerDrawer: React.FC<HomeworkComposerDrawerProps> = ({ open, o
                         <TextField
                           fullWidth
                           label="Theme"
-                          placeholder="Wildlife conservation"
+                          placeholder="General Topic"
                           value={listeningTheme}
                           onChange={(e) => setListeningTheme(e.target.value)}
                         />
@@ -835,19 +839,6 @@ const HomeworkComposerDrawer: React.FC<HomeworkComposerDrawerProps> = ({ open, o
                         <TextField select label="Narration style" value={listeningStyle} onChange={(e) => setListeningStyle(e.target.value)} fullWidth>
                           {styleOptions.map(style => <MenuItem key={style} value={style}>{style}</MenuItem>)}
                         </TextField>
-                        <TextField
-                          label="Seed (optional)"
-                          value={listeningSeed}
-                          onChange={(e) => {
-                            const val = e.target.value;
-                            if (/^-?\d*$/.test(val)) {
-                              setListeningSeed(val);
-                            }
-                          }}
-                          placeholder="42"
-                          inputProps={{ inputMode: 'numeric', pattern: '-?[0-9]*' }}
-                          fullWidth
-                        />
                       </Stack>
 
                       <FormControlLabel

--- a/src/pages/homework/TeacherHomeworkNewPage.tsx
+++ b/src/pages/homework/TeacherHomeworkNewPage.tsx
@@ -1,16 +1,45 @@
-import React, { useEffect, useState } from 'react';
-import { Box, Button, Container, Grid, MenuItem, Stack, TextField, Typography, Autocomplete, CircularProgress, Chip, Dialog, DialogTitle, DialogContent, DialogActions, FormControlLabel, Checkbox } from '@mui/material';
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Autocomplete,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Container,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  Grid,
+  MenuItem,
+  Paper,
+  Slider,
+  Stack,
+  TextField,
+  Typography,
+  Checkbox,
+  Divider,
+} from '@mui/material';
 import { CreateAssignmentDto, HomeworkTaskType, SourceKind } from '../../types/homework';
 import { useAuth } from '../../context/AuthContext';
 import { useCreateAssignment } from '../../hooks/useHomeworks';
 import { useAssignWords } from '../../hooks/useAssignments';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { toOffsetDateTime } from '../../utils/datetime';
-import { fetchStudents, fetchUserById } from '../../services/api';
-import { useQuery } from '@tanstack/react-query';
+import { fetchStudents, fetchUserById, generateListeningTranscript, updateListeningTranscript, validateListeningTranscript } from '../../services/api';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { vocabApi } from '../../services/vocabulary.api';
 import VocabularyList from '../../components/vocabulary/VocabularyList';
-import type { VocabularyWord } from '../../types';
+import type {
+  GenerateListeningTranscriptPayload,
+  ListeningTranscriptResponse,
+  ValidateListeningTranscriptPayload,
+  ValidateListeningTranscriptResponse,
+  VocabularyWord,
+} from '../../types';
+import { ENGLISH_LEVELS } from '../../types/ENGLISH_LEVELS';
 
 const TeacherHomeworkNewPage: React.FC = () => {
   const { user } = useAuth();
@@ -42,7 +71,31 @@ const TeacherHomeworkNewPage: React.FC = () => {
   const [shuffle, setShuffle] = useState<boolean>(true);
   const [timeLimitMin, setTimeLimitMin] = useState<string>('');
 
+  // Listening transcript generation state
+  const [listeningDurationSecTarget, setListeningDurationSecTarget] = useState<number>(90);
+  const [listeningTheme, setListeningTheme] = useState('');
+  const [listeningLanguage, setListeningLanguage] = useState('en-US');
+  const [listeningCefr, setListeningCefr] = useState('B1');
+  const [listeningStyle, setListeningStyle] = useState('neutral');
+  const [listeningSeed, setListeningSeed] = useState('');
+  const [listeningMustIncludeAll, setListeningMustIncludeAll] = useState(true);
+  const [transcriptId, setTranscriptId] = useState<string | null>(null);
+  const [transcriptDraft, setTranscriptDraft] = useState('');
+  const [transcriptMetadata, setTranscriptMetadata] = useState<ListeningTranscriptResponse['metadata']>({
+    language: listeningLanguage,
+    theme: listeningTheme,
+    cefr: listeningCefr,
+    style: listeningStyle,
+  });
+  const [estimatedDurationSec, setEstimatedDurationSec] = useState<number | null>(null);
+  const [wordCoverage, setWordCoverage] = useState<Record<string, boolean>>({});
+  const [coverageMissing, setCoverageMissing] = useState<string[]>([]);
+  const [transcriptError, setTranscriptError] = useState<string | null>(null);
+  const [transcriptInfo, setTranscriptInfo] = useState<string | null>(null);
+  const [hasUnsavedTranscriptEdits, setHasUnsavedTranscriptEdits] = useState(false);
+
   const isVocabList = taskType === 'VOCAB' && sourceKind === 'VOCAB_LIST';
+  const isListeningTask = taskType === 'LISTENING';
 
   // Load vocabulary words
   const { data: allWords = [] } = useQuery<VocabularyWord[]>({
@@ -64,6 +117,230 @@ const TeacherHomeworkNewPage: React.FC = () => {
     const map = new Map(allWords.map(w => [w.id, w] as const));
     return selectedWordIds.map(id => map.get(id)).filter(Boolean) as VocabularyWord[];
   }, [allWords, selectedWordIds]);
+
+  const numericWordIds = useMemo(() => {
+    return selectedWordIds
+      .map((id) => Number(id))
+      .filter((num) => Number.isFinite(num) && !Number.isNaN(num));
+  }, [selectedWordIds]);
+
+  const hasInvalidWordIds = selectedWordIds.length > 0 && numericWordIds.length !== selectedWordIds.length;
+  const listeningWordRequirementMet = selectedWordIds.length >= 3;
+
+  const cefrOptions = useMemo(() => Array.from(new Set(Object.values(ENGLISH_LEVELS).map(level => level.code))), []);
+  const languageOptions = useMemo(() => ['en-US', 'en-GB', 'en-AU', 'es-ES', 'fr-FR', 'de-DE'], []);
+  const styleOptions = useMemo(() => ['neutral', 'storytelling', 'documentary', 'conversational', 'inspirational'], []);
+  const taskTypeOptions: HomeworkTaskType[] = ['VIDEO', 'READING', 'GRAMMAR', 'VOCAB', 'LISTENING', 'LINK'];
+  const durationMarks = useMemo(() => (
+    [
+      { value: 45, label: '0:45' },
+      { value: 60, label: '1:00' },
+      { value: 90, label: '1:30' },
+      { value: 120, label: '2:00' },
+    ]
+  ), []);
+  const sourceKindOptions: SourceKind[] = ['MATERIAL', 'LESSON_CONTENT', 'EXTERNAL_URL', 'VOCAB_LIST', 'GENERATED_AUDIO'];
+
+  const formatDurationLabel = (value: number) => {
+    const mins = Math.floor(value / 60);
+    const secs = Math.max(0, value % 60);
+    return `${mins}:${secs.toString().padStart(2, '0')}`;
+  };
+
+  const isVocabSelectionInvalid = selectedWordIds.length < 5 || selectedWordIds.length > 100;
+  const createDisabled =
+    create.isPending ||
+    !studentId ||
+    (isVocabList && isVocabSelectionInvalid) ||
+    (isListeningTask && (!transcriptId || hasUnsavedTranscriptEdits || !listeningWordRequirementMet || hasInvalidWordIds));
+
+  const generateTranscriptMutation = useMutation<ListeningTranscriptResponse, Error, GenerateListeningTranscriptPayload>({
+    mutationFn: (payload) => generateListeningTranscript(payload),
+  });
+  const updateTranscriptMutation = useMutation<ListeningTranscriptResponse, Error, { transcriptId: string; transcript: string }>(
+    {
+      mutationFn: ({ transcriptId, transcript }) =>
+        updateListeningTranscript(transcriptId, { transcript }),
+    }
+  );
+  const validateTranscriptMutation = useMutation<ValidateListeningTranscriptResponse, Error, ValidateListeningTranscriptPayload>({
+    mutationFn: (payload) => validateListeningTranscript(payload),
+  });
+
+  const coverageEntries = useMemo(() => {
+    if (selectedWordChips.length === 0) return [] as Array<{ word: string; covered: boolean }>;
+    return selectedWordChips.map((word) => {
+      const normalized = word.text.trim();
+      const lower = normalized.toLowerCase();
+      const covered = Boolean(
+        wordCoverage[normalized] ?? wordCoverage[lower] ?? wordCoverage[word.text] ?? false,
+      );
+      return { word: normalized, covered };
+    });
+  }, [selectedWordChips, wordCoverage]);
+
+  const formattedEstimatedDuration = useMemo(() => {
+    if (estimatedDurationSec == null) return null;
+    const mins = Math.floor(estimatedDurationSec / 60);
+    const secs = Math.max(0, estimatedDurationSec % 60);
+    return `${mins}:${secs.toString().padStart(2, '0')}`;
+  }, [estimatedDurationSec]);
+
+  useEffect(() => {
+    if (isListeningTask) {
+      setSourceKind('GENERATED_AUDIO');
+    } else if (sourceKind === 'GENERATED_AUDIO') {
+      setSourceKind('EXTERNAL_URL');
+    }
+  }, [isListeningTask, sourceKind]);
+
+  useEffect(() => {
+    if (!isListeningTask) {
+      setTranscriptId(null);
+      setTranscriptDraft('');
+      setWordCoverage({});
+      setCoverageMissing([]);
+      setEstimatedDurationSec(null);
+      setTranscriptError(null);
+      setTranscriptInfo(null);
+      setHasUnsavedTranscriptEdits(false);
+    }
+  }, [isListeningTask]);
+
+  useEffect(() => {
+    if (!isListeningTask || transcriptId) return;
+    setTranscriptMetadata({
+      language: listeningLanguage,
+      theme: listeningTheme || undefined,
+      cefr: listeningCefr,
+      style: listeningStyle,
+    });
+  }, [isListeningTask, transcriptId, listeningLanguage, listeningTheme, listeningCefr, listeningStyle]);
+
+  const buildCoverageMissing = (coverage: Record<string, boolean> | undefined) =>
+    Object.entries(coverage ?? {})
+      .filter(([, covered]) => !covered)
+      .map(([word]) => word);
+
+  const handleGenerateTranscript = async () => {
+    setTranscriptError(null);
+    setTranscriptInfo(null);
+
+    if (!isListeningTask) return;
+
+    if (!listeningWordRequirementMet) {
+      setTranscriptError('Select at least 3 focus words to guide the story.');
+      return;
+    }
+
+    if (hasInvalidWordIds) {
+      setTranscriptError('Some selected words are unavailable for generation.');
+      return;
+    }
+
+    const payload: GenerateListeningTranscriptPayload = {
+      wordIds: numericWordIds,
+      durationSecTarget: listeningDurationSecTarget,
+      theme: listeningTheme || undefined,
+      cefr: listeningCefr || undefined,
+      language: listeningLanguage || undefined,
+      style: listeningStyle || undefined,
+      constraints: listeningMustIncludeAll ? { mustIncludeAllWords: true } : undefined,
+    };
+
+    if (listeningSeed.trim()) {
+      const parsedSeed = Number(listeningSeed.trim());
+      if (Number.isNaN(parsedSeed)) {
+        setTranscriptError('Seed must be a number.');
+        return;
+      }
+      payload.seed = parsedSeed;
+    }
+
+    try {
+      const result = await generateTranscriptMutation.mutateAsync(payload);
+      setTranscriptId(result.transcriptId);
+      setTranscriptDraft(result.transcript ?? '');
+      setWordCoverage(result.wordCoverage ?? {});
+      setCoverageMissing(buildCoverageMissing(result.wordCoverage));
+      setEstimatedDurationSec(result.estimatedDurationSec ?? null);
+      setTranscriptMetadata(
+        result.metadata ?? {
+          language: listeningLanguage,
+          theme: listeningTheme || undefined,
+          cefr: listeningCefr,
+          style: listeningStyle,
+        },
+      );
+      setHasUnsavedTranscriptEdits(false);
+      setTranscriptInfo('Transcript generated. Tweak the draft if needed, then save.');
+    } catch (error) {
+      console.error('Failed to generate transcript', error);
+      setTranscriptError(
+        error instanceof Error ? error.message : 'Failed to generate transcript. Please try again.',
+      );
+    }
+  };
+
+  const handleSaveTranscript = async () => {
+    if (!transcriptId) return;
+
+    setTranscriptError(null);
+    setTranscriptInfo(null);
+
+    try {
+      const result = await updateTranscriptMutation.mutateAsync({
+        transcriptId,
+        transcript: transcriptDraft.trim(),
+      });
+      setTranscriptDraft(result.transcript ?? transcriptDraft);
+      setWordCoverage(result.wordCoverage ?? {});
+      setCoverageMissing(buildCoverageMissing(result.wordCoverage));
+      setEstimatedDurationSec(result.estimatedDurationSec ?? estimatedDurationSec);
+      setTranscriptMetadata(result.metadata ?? transcriptMetadata);
+      setHasUnsavedTranscriptEdits(false);
+      setTranscriptInfo('Transcript saved.');
+    } catch (error) {
+      console.error('Failed to save transcript', error);
+      setTranscriptError(
+        error instanceof Error ? error.message : 'Could not save transcript. Please try again.',
+      );
+    }
+  };
+
+  const handleValidateTranscript = async () => {
+    setTranscriptError(null);
+    setTranscriptInfo(null);
+
+    if (!transcriptDraft.trim()) {
+      setTranscriptError('Transcript text cannot be empty.');
+      return;
+    }
+
+    if (!listeningWordRequirementMet || hasInvalidWordIds) {
+      setTranscriptError('Make sure you selected valid vocabulary words before validating.');
+      return;
+    }
+
+    try {
+      const result = await validateTranscriptMutation.mutateAsync({
+        transcript: transcriptDraft,
+        wordIds: numericWordIds,
+      });
+      setWordCoverage(result.wordCoverage ?? {});
+      setCoverageMissing(buildCoverageMissing(result.wordCoverage));
+      setTranscriptInfo(
+        result.missing.length === 0
+          ? 'Every target word is present. Ready for audio!'
+          : 'Some words are still missing. Consider tweaking the text.',
+      );
+    } catch (error) {
+      console.error('Failed to validate transcript', error);
+      setTranscriptError(
+        error instanceof Error ? error.message : 'Validation failed. Try again in a moment.',
+      );
+    }
+  };
 
   // fetch student options debounced by query
   useEffect(() => {
@@ -110,6 +387,51 @@ const TeacherHomeworkNewPage: React.FC = () => {
         sourceKind: 'VOCAB_LIST',
         instructions: undefined,
         contentRef: { wordIds: selectedWordIds, settings },
+        vocabWordIds: selectedWordIds,
+      });
+    } else if (isListeningTask) {
+      setTranscriptError(null);
+      setTranscriptInfo(null);
+      if (!transcriptId) {
+        setTranscriptError('Generate the transcript before creating the homework.');
+        return;
+      }
+
+      if (hasUnsavedTranscriptEdits) {
+        setTranscriptError('Save your transcript edits before continuing.');
+        return;
+      }
+
+      if (!listeningWordRequirementMet || hasInvalidWordIds) {
+        setTranscriptError('Please verify the selected vocabulary before creating the task.');
+        return;
+      }
+
+      const generatorParams = {
+        wordIds: numericWordIds,
+        durationSecTarget: listeningDurationSecTarget,
+        theme: listeningTheme || undefined,
+        cefr: listeningCefr || undefined,
+        language: listeningLanguage || undefined,
+        style: listeningStyle || undefined,
+        constraints: listeningMustIncludeAll ? { mustIncludeAllWords: true } : undefined,
+        seed: listeningSeed.trim() ? Number(listeningSeed.trim()) : undefined,
+      };
+
+      tasks.push({
+        title: taskTitle,
+        type: 'LISTENING',
+        sourceKind: 'GENERATED_AUDIO',
+        instructions: undefined,
+        contentRef: {
+          transcriptId,
+          transcript: transcriptDraft.trim(),
+          wordIds: numericWordIds,
+          estimatedDurationSec: estimatedDurationSec ?? listeningDurationSecTarget,
+          metadata: transcriptMetadata,
+          wordCoverage,
+          generatorParams,
+        },
         vocabWordIds: selectedWordIds,
       });
     } else {
@@ -202,20 +524,32 @@ const TeacherHomeworkNewPage: React.FC = () => {
             <Typography variant="subtitle1">Task</Typography>
             <TextField label="Task title" value={taskTitle} onChange={e => setTaskTitle(e.target.value)} fullWidth />
             <TextField select label="Task type" value={taskType} onChange={e => setTaskType(e.target.value as HomeworkTaskType)}>
-              {['VIDEO','READING','GRAMMAR','VOCAB','LINK'].map(t => (<MenuItem key={t} value={t}>{t}</MenuItem>))}
+              {taskTypeOptions.map(t => (<MenuItem key={t} value={t}>{t}</MenuItem>))}
             </TextField>
-            <TextField select label="Source kind" value={sourceKind} onChange={e => setSourceKind(e.target.value as SourceKind)}>
-              {['MATERIAL','LESSON_CONTENT','EXTERNAL_URL','VOCAB_LIST'].map(s => (<MenuItem key={s} value={s}>{s}</MenuItem>))}
-            </TextField>
-            {sourceKind === 'EXTERNAL_URL' && (
+            {!isListeningTask ? (
+              <TextField select label="Source kind" value={sourceKind} onChange={e => setSourceKind(e.target.value as SourceKind)}>
+                {sourceKindOptions.filter(s => s !== 'GENERATED_AUDIO').map(s => (<MenuItem key={s} value={s}>{s}</MenuItem>))}
+              </TextField>
+            ) : (
+              <TextField label="Source kind" value="GENERATED_AUDIO" InputProps={{ readOnly: true }} disabled />
+            )}
+            {sourceKind === 'EXTERNAL_URL' && !isListeningTask && (
               <TextField label="Source URL" value={sourceUrl} onChange={e => setSourceUrl(e.target.value)} fullWidth />
             )}
-            {isVocabList && (
+            {(isVocabList || isListeningTask) && (
               <Stack spacing={1} sx={{ mt: 1 }}>
                 <Stack direction="row" spacing={1} alignItems="center">
-                  <Button variant="outlined" onClick={() => setPickerOpen(true)}>Select words</Button>
-                  <Chip size="small" color={selectedWordIds.length >= 5 ? 'success' : 'warning'} label={`${selectedWordIds.length} selected`} />
-                  <Typography variant="caption" color="text.secondary">Choose 5–100 words</Typography>
+                  <Button variant="outlined" onClick={() => setPickerOpen(true)}>
+                    {isListeningTask ? 'Pick focus words' : 'Select words'}
+                  </Button>
+                  <Chip
+                    size="small"
+                    color={isVocabList ? (!isVocabSelectionInvalid ? 'success' : 'warning') : (listeningWordRequirementMet && !hasInvalidWordIds ? 'success' : 'warning')}
+                    label={`${selectedWordIds.length} selected`}
+                  />
+                  <Typography variant="caption" color="text.secondary">
+                    {isVocabList ? 'Choose 5–100 words' : 'Pick 3+ words to anchor the transcript'}
+                  </Typography>
                 </Stack>
                 {selectedWordChips.length > 0 && (
                   <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
@@ -227,28 +561,197 @@ const TeacherHomeworkNewPage: React.FC = () => {
                     )}
                   </Stack>
                 )}
-                {(selectedWordIds.length < 5 || selectedWordIds.length > 100) && (
+                {isVocabList && isVocabSelectionInvalid && (
                   <Typography variant="caption" color="error">Please select between 5 and 100 words.</Typography>
                 )}
-                <TextField type="number" label="Mastery streak" value={masteryStreak}
-                           onChange={e => setMasteryStreak(Math.max(1, Math.min(10, Number(e.target.value) || 0)))}
-                           InputLabelProps={{ shrink: true }} inputProps={{ min: 1, max: 10 }} />
-                <FormControlLabel control={<Checkbox checked={shuffle} onChange={(e)=> setShuffle(e.target.checked)} />} label="Shuffle words" />
-                <TextField type="number" label="Time limit (minutes)" value={timeLimitMin}
-                           onChange={e => setTimeLimitMin(e.target.value)} InputLabelProps={{ shrink: true }}
-                           helperText="Optional: leave empty for no timer" />
+                {isListeningTask && (!listeningWordRequirementMet || hasInvalidWordIds) && (
+                  <Typography variant="caption" color="error">
+                    {hasInvalidWordIds ? 'Some selected words could not be parsed. Please reselect them.' : 'Please select at least 3 words to proceed.'}
+                  </Typography>
+                )}
+                {isVocabList && (
+                  <>
+                    <TextField type="number" label="Mastery streak" value={masteryStreak}
+                               onChange={e => setMasteryStreak(Math.max(1, Math.min(10, Number(e.target.value) || 0)))}
+                               InputLabelProps={{ shrink: true }} inputProps={{ min: 1, max: 10 }} />
+                    <FormControlLabel control={<Checkbox checked={shuffle} onChange={(e)=> setShuffle(e.target.checked)} />} label="Shuffle words" />
+                    <TextField type="number" label="Time limit (minutes)" value={timeLimitMin}
+                               onChange={e => setTimeLimitMin(e.target.value)} InputLabelProps={{ shrink: true }}
+                               helperText="Optional: leave empty for no timer" />
+                  </>
+                )}
+                {isListeningTask && (
+                  <Typography variant="caption" color="text.secondary">
+                    Vocabulary mastery settings are ignored for listening tasks.
+                  </Typography>
+                )}
               </Stack>
+            )}
+            {isListeningTask && (
+              <Paper elevation={0} sx={{ p: 2.5, borderRadius: 3, border: '1px solid rgba(37,115,255,0.12)', background: '#ffffff' }}>
+                <Stack spacing={2.5}>
+                  <Box>
+                    <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>AI transcript lab</Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      Shape the scenario, then let the AI craft a script that weaves in every chosen word.
+                    </Typography>
+                  </Box>
+
+                  {(transcriptError || transcriptInfo) && (
+                    <Stack spacing={1}>
+                      {transcriptError && <Alert severity="error">{transcriptError}</Alert>}
+                      {transcriptInfo && !transcriptError && <Alert severity="success">{transcriptInfo}</Alert>}
+                    </Stack>
+                  )}
+
+                  <Stack spacing={2}>
+                    <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems="stretch">
+                      <Box flex={1}>
+                        <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1 }}>Target duration</Typography>
+                        <Slider
+                          value={listeningDurationSecTarget}
+                          onChange={(_, value) => setListeningDurationSecTarget(Array.isArray(value) ? value[0] : value)}
+                          min={45}
+                          max={150}
+                          step={15}
+                          marks={durationMarks}
+                          valueLabelDisplay="on"
+                          valueLabelFormat={(value) => formatDurationLabel(value as number)}
+                          sx={{ px: 1 }}
+                        />
+                      </Box>
+                      <TextField
+                        fullWidth
+                        label="Theme"
+                        placeholder="Wildlife conservation"
+                        value={listeningTheme}
+                        onChange={(e) => setListeningTheme(e.target.value)}
+                      />
+                    </Stack>
+
+                    <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+                      <TextField select label="Language" value={listeningLanguage} onChange={(e) => setListeningLanguage(e.target.value)} fullWidth>
+                        {languageOptions.map(lang => <MenuItem key={lang} value={lang}>{lang}</MenuItem>)}
+                      </TextField>
+                      <TextField select label="CEFR" value={listeningCefr} onChange={(e) => setListeningCefr(e.target.value)} fullWidth>
+                        {cefrOptions.map(level => <MenuItem key={level} value={level}>{level}</MenuItem>)}
+                      </TextField>
+                    </Stack>
+
+                    <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+                      <TextField select label="Narration style" value={listeningStyle} onChange={(e) => setListeningStyle(e.target.value)} fullWidth>
+                        {styleOptions.map(style => <MenuItem key={style} value={style}>{style}</MenuItem>)}
+                      </TextField>
+                      <TextField
+                        label="Seed (optional)"
+                        value={listeningSeed}
+                        onChange={(e) => {
+                          const val = e.target.value;
+                          if (/^-?\d*$/.test(val)) {
+                            setListeningSeed(val);
+                          }
+                        }}
+                        placeholder="42"
+                        inputProps={{ inputMode: 'numeric', pattern: '-?[0-9]*' }}
+                        fullWidth
+                      />
+                    </Stack>
+
+                    <FormControlLabel
+                      control={<Checkbox checked={listeningMustIncludeAll} onChange={(e) => setListeningMustIncludeAll(e.target.checked)} />}
+                      label="Force every selected word to appear"
+                    />
+                  </Stack>
+
+                  <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems={{ xs: 'stretch', sm: 'center' }}>
+                    <Button
+                      variant="contained"
+                      onClick={handleGenerateTranscript}
+                      disabled={generateTranscriptMutation.isPending}
+                      sx={{ minWidth: 200 }}
+                    >
+                      {generateTranscriptMutation.isPending ? <CircularProgress size={18} sx={{ color: 'white' }} /> : 'Generate transcript'}
+                    </Button>
+                    <Button
+                      variant="outlined"
+                      onClick={handleValidateTranscript}
+                      disabled={validateTranscriptMutation.isPending || !transcriptDraft}
+                    >
+                      {validateTranscriptMutation.isPending ? <CircularProgress size={18} /> : 'Validate coverage'}
+                    </Button>
+                    <Button
+                      variant="outlined"
+                      color="success"
+                      onClick={handleSaveTranscript}
+                      disabled={!transcriptId || !hasUnsavedTranscriptEdits || updateTranscriptMutation.isPending}
+                    >
+                      {updateTranscriptMutation.isPending ? <CircularProgress size={18} /> : 'Save edits'}
+                    </Button>
+                  </Stack>
+
+                  <Divider sx={{ my: 1 }} />
+
+                  <Stack spacing={1.5}>
+                    <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>Transcript draft</Typography>
+                    <TextField
+                      value={transcriptDraft}
+                      onChange={(e) => {
+                        setTranscriptDraft(e.target.value);
+                        setHasUnsavedTranscriptEdits(true);
+                      }}
+                      multiline
+                      minRows={6}
+                      placeholder="The rainforest is a vibrant, sustainable habitat..."
+                    />
+                    <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems={{ xs: 'flex-start', sm: 'center' }}>
+                      {formattedEstimatedDuration && (
+                        <Typography variant="body2" color="text.secondary">
+                          Estimated runtime: {formattedEstimatedDuration}
+                        </Typography>
+                      )}
+                      {transcriptMetadata?.language && (
+                        <Typography variant="body2" color="text.secondary">
+                          {transcriptMetadata.language} • {transcriptMetadata.cefr ?? listeningCefr} • {transcriptMetadata.style ?? listeningStyle}
+                        </Typography>
+                      )}
+                    </Stack>
+                    {coverageEntries.length > 0 && (
+                      <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
+                        {coverageEntries.map(({ word, covered }) => (
+                          <Chip
+                            key={word}
+                            label={word}
+                            size="small"
+                            color={covered ? 'success' : 'warning'}
+                            variant={covered ? 'filled' : 'outlined'}
+                          />
+                        ))}
+                      </Stack>
+                    )}
+                    {coverageMissing.length > 0 && (
+                      <Typography variant="caption" color="error">
+                        Missing words: {coverageMissing.join(', ')}
+                      </Typography>
+                    )}
+                    {hasUnsavedTranscriptEdits && (
+                      <Typography variant="caption" color="warning.main">
+                        You have unsaved edits. Save before assigning.
+                      </Typography>
+                    )}
+                  </Stack>
+                </Stack>
+              </Paper>
             )}
           </Stack>
         </Grid>
       </Grid>
 
       <Box mt={3}>
-        <Button variant="contained" onClick={onSubmit} disabled={create.isPending || !studentId || (isVocabList && (selectedWordIds.length < 5 || selectedWordIds.length > 100))}>Create</Button>
+        <Button variant="contained" onClick={onSubmit} disabled={createDisabled}>Create</Button>
       </Box>
 
       <Dialog open={pickerOpen} onClose={() => setPickerOpen(false)} fullWidth maxWidth="md">
-        <DialogTitle>Select vocabulary words</DialogTitle>
+        <DialogTitle>{isListeningTask ? 'Select listening words' : 'Select vocabulary words'}</DialogTitle>
         <DialogContent>
           <Stack spacing={2} sx={{ mt: 1 }}>
             <TextField label="Search" value={wordSearch} onChange={e => setWordSearch(e.target.value)} fullWidth />

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -2,7 +2,15 @@ import axios from 'axios';
 import {Student} from "../pages/MyStudentsPage";
 import { NotificationMessage} from "../context/NotificationsSocketContext";
 import { ApiError } from '../context/ApiErrorContext';
-import {GenerateExerciseRequest, GenerateExerciseResponse} from "../types";
+import {
+    GenerateExerciseRequest,
+    GenerateExerciseResponse,
+    GenerateListeningTranscriptPayload,
+    ListeningTranscriptResponse,
+    ValidateListeningTranscriptPayload,
+    ValidateListeningTranscriptResponse,
+    UpdateListeningTranscriptPayload,
+} from "../types";
 import { LESSON_CONTENTS_BASE } from '../constants/api';
 import type { PageModel, BlockContentPayload } from '../types/lessonContent';
 
@@ -615,6 +623,46 @@ export interface MicDiagPayload {
 export const postMicDiag = async (payload: MicDiagPayload) => {
   const res = await api.post(`/users-service/api/diag/mic-log`, payload);
   return res.data;
+};
+
+export const generateListeningTranscript = async (
+  payload: GenerateListeningTranscriptPayload,
+): Promise<ListeningTranscriptResponse> => {
+  const response = await api.post<ListeningTranscriptResponse>(
+    `/lessons-service/api/listening/transcripts:generate`,
+    payload,
+  );
+  return response.data;
+};
+
+export const updateListeningTranscript = async (
+  transcriptId: string,
+  payload: UpdateListeningTranscriptPayload,
+): Promise<ListeningTranscriptResponse> => {
+  const response = await api.put<ListeningTranscriptResponse>(
+    `/lessons-service/api/listening/transcripts/${transcriptId}`,
+    payload,
+  );
+  return response.data;
+};
+
+export const getListeningTranscript = async (
+  transcriptId: string,
+): Promise<ListeningTranscriptResponse> => {
+  const response = await api.get<ListeningTranscriptResponse>(
+    `/lessons-service/api/listening/transcripts/${transcriptId}`,
+  );
+  return response.data;
+};
+
+export const validateListeningTranscript = async (
+  payload: ValidateListeningTranscriptPayload,
+): Promise<ValidateListeningTranscriptResponse> => {
+  const response = await api.post<ValidateListeningTranscriptResponse>(
+    `/lessons-service/api/listening/transcripts:validate`,
+    payload,
+  );
+  return response.data;
 };
 
 export default api;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -626,31 +626,37 @@ export const postMicDiag = async (payload: MicDiagPayload) => {
 };
 
 export const generateListeningTranscript = async (
+  teacherId: string,
   payload: GenerateListeningTranscriptPayload,
 ): Promise<ListeningTranscriptResponse> => {
   const response = await api.post<ListeningTranscriptResponse>(
-    `/lessons-service/api/listening/transcripts:generate`,
+    `/lessons-service/api/listening/transcripts/generate`,
     payload,
+    { params: { teacherId } },
   );
   return response.data;
 };
 
 export const updateListeningTranscript = async (
+  teacherId: string,
   transcriptId: string,
   payload: UpdateListeningTranscriptPayload,
 ): Promise<ListeningTranscriptResponse> => {
   const response = await api.put<ListeningTranscriptResponse>(
     `/lessons-service/api/listening/transcripts/${transcriptId}`,
     payload,
+    { params: { teacherId } },
   );
   return response.data;
 };
 
 export const getListeningTranscript = async (
+  teacherId: string,
   transcriptId: string,
 ): Promise<ListeningTranscriptResponse> => {
   const response = await api.get<ListeningTranscriptResponse>(
     `/lessons-service/api/listening/transcripts/${transcriptId}`,
+    { params: { teacherId } },
   );
   return response.data;
 };
@@ -659,7 +665,7 @@ export const validateListeningTranscript = async (
   payload: ValidateListeningTranscriptPayload,
 ): Promise<ValidateListeningTranscriptResponse> => {
   const response = await api.post<ValidateListeningTranscriptResponse>(
-    `/lessons-service/api/listening/transcripts:validate`,
+    `/lessons-service/api/listening/transcripts/validate`,
     payload,
   );
   return response.data;

--- a/src/types/homework.ts
+++ b/src/types/homework.ts
@@ -1,8 +1,13 @@
 // Homework domain types matching backend
 
-export type HomeworkTaskType = 'VIDEO' | 'READING' | 'GRAMMAR' | 'VOCAB' | 'LINK';
+export type HomeworkTaskType = 'VIDEO' | 'READING' | 'GRAMMAR' | 'VOCAB' | 'LINK' | 'LISTENING';
 export type HomeworkTaskStatus = 'NOT_STARTED' | 'IN_PROGRESS' | 'COMPLETED';
-export type SourceKind = 'MATERIAL' | 'LESSON_CONTENT' | 'EXTERNAL_URL' | 'VOCAB_LIST';
+export type SourceKind =
+  | 'MATERIAL'
+  | 'LESSON_CONTENT'
+  | 'EXTERNAL_URL'
+  | 'VOCAB_LIST'
+  | 'GENERATED_AUDIO';
 
 export interface TaskDto {
   id: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -51,3 +51,5 @@ export interface GenerateExerciseResponse {
     tokensUsed: number;
   };
 }
+
+export * from './listeningTranscript';

--- a/src/types/listeningTranscript.ts
+++ b/src/types/listeningTranscript.ts
@@ -1,0 +1,39 @@
+export interface ListeningTranscriptMetadata {
+  language?: string;
+  theme?: string;
+  cefr?: string;
+  style?: string;
+}
+
+export interface ListeningTranscriptResponse {
+  transcriptId: string;
+  transcript: string;
+  wordCoverage: Record<string, boolean>;
+  estimatedDurationSec?: number;
+  metadata?: ListeningTranscriptMetadata;
+}
+
+export interface GenerateListeningTranscriptPayload {
+  wordIds: number[];
+  durationSecTarget: number;
+  theme?: string;
+  cefr?: string;
+  language?: string;
+  style?: string;
+  seed?: number;
+  constraints?: { mustIncludeAllWords?: boolean };
+}
+
+export interface UpdateListeningTranscriptPayload {
+  transcript: string;
+}
+
+export interface ValidateListeningTranscriptPayload {
+  transcript: string;
+  wordIds: number[];
+}
+
+export interface ValidateListeningTranscriptResponse {
+  wordCoverage: Record<string, boolean>;
+  missing: string[];
+}

--- a/src/types/listeningTranscript.ts
+++ b/src/types/listeningTranscript.ts
@@ -3,6 +3,7 @@ export interface ListeningTranscriptMetadata {
   theme?: string;
   cefr?: string;
   style?: string;
+  [key: string]: unknown;
 }
 
 export interface ListeningTranscriptResponse {
@@ -14,14 +15,14 @@ export interface ListeningTranscriptResponse {
 }
 
 export interface GenerateListeningTranscriptPayload {
-  wordIds: number[];
+  wordIds: string[];
   durationSecTarget: number;
   theme?: string;
   cefr?: string;
   language?: string;
   style?: string;
   seed?: number;
-  constraints?: { mustIncludeAllWords?: boolean };
+  constraints?: Record<string, unknown>;
 }
 
 export interface UpdateListeningTranscriptPayload {
@@ -30,7 +31,7 @@ export interface UpdateListeningTranscriptPayload {
 
 export interface ValidateListeningTranscriptPayload {
   transcript: string;
-  wordIds: number[];
+  wordIds: string[];
 }
 
 export interface ValidateListeningTranscriptResponse {


### PR DESCRIPTION
## Summary
- introduce a LISTENING homework task type with generated audio source kind
- add transcript generation, editing, and validation UI to the homework composer
- wire up API helpers for transcript lifecycle endpoints and surface word coverage feedback

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d79d0cf4b8832cbae524cb66999346