### PR TITLE
Implement listening homework audio generation and playback

### DIFF
--- a/src/components/homework/HomeworkComposerDrawer.tsx
+++ b/src/components/homework/HomeworkComposerDrawer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  Alert,
   Autocomplete,
   Box,
   Button,
@@ -9,28 +10,45 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
+  Divider,
   Drawer,
   FormControlLabel,
   Checkbox,
   IconButton,
   MenuItem,
   Paper,
+  Slider,
   Stack,
   TextField,
   Typography,
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import ContentPasteIcon from '@mui/icons-material/ContentPaste';
-import {useQuery} from '@tanstack/react-query';
+import {useMutation, useQuery} from '@tanstack/react-query';
 import {useAuth} from '../../context/AuthContext';
 import {useCreateAssignment} from '../../hooks/useHomeworks';
 import {useAssignWords} from '../../hooks/useAssignments';
 import {CreateAssignmentDto, HomeworkTaskType, SourceKind, AssignmentDto} from '../../types/homework';
 import {toOffsetDateTime} from '../../utils/datetime';
-import {fetchStudents, fetchUserById} from '../../services/api';
+import {
+  fetchStudents,
+  fetchUserById,
+  generateListeningTranscript,
+  updateListeningTranscript,
+  validateListeningTranscript,
+} from '../../services/api';
 import {vocabApi} from '../../services/vocabulary.api';
 import VocabularyList from '../vocabulary/VocabularyList';
-import type {VocabularyWord} from '../../types';
+import type {
+  GenerateListeningTranscriptPayload,
+  ListeningGeneratedAudioContentRef,
+  ListeningTranscriptResponse,
+  ValidateListeningTranscriptPayload,
+  ValidateListeningTranscriptResponse,
+  VocabularyWord,
+} from '../../types';
+import ListeningAudioGenerationPanel from '../listening/ListeningAudioGenerationPanel';
+import { ENGLISH_LEVELS } from '../../types/ENGLISH_LEVELS';
 
 export interface HomeworkComposerDrawerProps {
   open: boolean;
@@ -74,7 +92,32 @@ const HomeworkComposerDrawer: React.FC<HomeworkComposerDrawerProps> = ({ open, o
   const [shuffle, setShuffle] = React.useState<boolean>(true);
   const [timeLimitMin, setTimeLimitMin] = React.useState<string>('');
 
+  // Listening transcript generation state
+  const [listeningDurationSecTarget, setListeningDurationSecTarget] = React.useState<number>(90);
+  const [listeningTheme, setListeningTheme] = React.useState('');
+  const [listeningLanguage, setListeningLanguage] = React.useState('en-US');
+  const [listeningCefr, setListeningCefr] = React.useState('B1');
+  const [listeningStyle, setListeningStyle] = React.useState('neutral');
+  const [listeningSeed, setListeningSeed] = React.useState('');
+  const [listeningMustIncludeAll, setListeningMustIncludeAll] = React.useState(true);
+  const [transcriptId, setTranscriptId] = React.useState<string | null>(null);
+  const [transcriptDraft, setTranscriptDraft] = React.useState('');
+  const [transcriptMetadata, setTranscriptMetadata] = React.useState<ListeningTranscriptResponse['metadata']>({
+    language: listeningLanguage,
+    theme: listeningTheme,
+    cefr: listeningCefr,
+    style: listeningStyle,
+  });
+  const [estimatedDurationSec, setEstimatedDurationSec] = React.useState<number | null>(null);
+  const [wordCoverage, setWordCoverage] = React.useState<Record<string, boolean>>({});
+  const [coverageMissing, setCoverageMissing] = React.useState<string[]>([]);
+  const [transcriptError, setTranscriptError] = React.useState<string | null>(null);
+  const [transcriptInfo, setTranscriptInfo] = React.useState<string | null>(null);
+  const [hasUnsavedTranscriptEdits, setHasUnsavedTranscriptEdits] = React.useState(false);
+  const [audioContentRef, setAudioContentRef] = React.useState<ListeningGeneratedAudioContentRef | null>(null);
+
   const isVocabList = taskType === 'VOCAB' && sourceKind === 'VOCAB_LIST';
+  const isListeningTask = taskType === 'LISTENING';
 
   // Load vocabulary words
   const { data: allWords = [] } = useQuery<VocabularyWord[]>({
@@ -96,6 +139,33 @@ const HomeworkComposerDrawer: React.FC<HomeworkComposerDrawerProps> = ({ open, o
     const map = new Map(allWords.map(w => [w.id, w] as const));
     return selectedWordIds.map(id => map.get(id)).filter(Boolean) as VocabularyWord[];
   }, [allWords, selectedWordIds]);
+
+  const listeningWordIds = React.useMemo(
+    () => selectedWordIds.filter((id) => id && id.trim().length > 0),
+    [selectedWordIds],
+  );
+
+  const listeningWordRequirementMet = listeningWordIds.length >= 3;
+
+  const cefrOptions = React.useMemo(() => Array.from(new Set(Object.values(ENGLISH_LEVELS).map(level => level.code))), []);
+  const languageOptions = React.useMemo(() => ['en-US', 'en-GB', 'en-AU', 'es-ES', 'fr-FR', 'de-DE'], []);
+  const styleOptions = React.useMemo(() => ['neutral', 'storytelling', 'documentary', 'conversational', 'inspirational'], []);
+  const taskTypeOptions: HomeworkTaskType[] = ['VIDEO', 'READING', 'GRAMMAR', 'VOCAB', 'LISTENING', 'LINK'];
+  const durationMarks = React.useMemo(() => (
+    [
+      { value: 45, label: '0:45' },
+      { value: 60, label: '1:00' },
+      { value: 90, label: '1:30' },
+      { value: 120, label: '2:00' },
+    ]
+  ), []);
+  const sourceKindOptions: SourceKind[] = ['MATERIAL', 'LESSON_CONTENT', 'EXTERNAL_URL', 'VOCAB_LIST', 'GENERATED_AUDIO'];
+
+  const formatDurationLabel = (value: number) => {
+    const mins = Math.floor(value / 60);
+    const secs = Math.max(0, value % 60);
+    return `${mins}:${secs.toString().padStart(2, '0')}`;
+  };
 
   // fetch student options debounced by query
   React.useEffect(() => {
@@ -147,6 +217,28 @@ const HomeworkComposerDrawer: React.FC<HomeworkComposerDrawerProps> = ({ open, o
       setMasteryStreak(2);
       setShuffle(true);
       setTimeLimitMin('');
+      setListeningDurationSecTarget(90);
+      setListeningTheme('');
+      setListeningLanguage('en-US');
+      setListeningCefr('B1');
+      setListeningStyle('neutral');
+      setListeningSeed('');
+      setListeningMustIncludeAll(true);
+      setTranscriptId(null);
+      setTranscriptDraft('');
+      setTranscriptMetadata({
+        language: 'en-US',
+        theme: undefined,
+        cefr: 'B1',
+        style: 'neutral',
+      });
+      setEstimatedDurationSec(null);
+      setWordCoverage({});
+      setCoverageMissing([]);
+      setTranscriptError(null);
+      setTranscriptInfo(null);
+      setHasUnsavedTranscriptEdits(false);
+      setAudioContentRef(null);
     }
   }, [open]);
 
@@ -156,17 +248,311 @@ const HomeworkComposerDrawer: React.FC<HomeworkComposerDrawerProps> = ({ open, o
     try { new URL(sourceUrl.trim()); return true; } catch { return false; }
   }, [sourceKind, sourceUrl]);
 
+  const isVocabSelectionInvalid = selectedWordIds.length < 5 || selectedWordIds.length > 100;
+
+  const generateTranscriptMutation = useMutation<
+    ListeningTranscriptResponse,
+    Error,
+    GenerateListeningTranscriptPayload
+  >({
+    mutationFn: async (payload) => {
+      if (!user?.id) {
+        throw new Error('You need to be signed in to generate transcripts.');
+      }
+      return generateListeningTranscript(user.id, payload);
+    },
+  });
+
+  const updateTranscriptMutation = useMutation<
+    ListeningTranscriptResponse,
+    Error,
+    { transcriptId: string; transcript: string }
+  >({
+    mutationFn: async ({ transcriptId, transcript }) => {
+      if (!user?.id) {
+        throw new Error('You need to be signed in to save transcripts.');
+      }
+      return updateListeningTranscript(user.id, transcriptId, { transcript });
+    },
+  });
+
+  const validateTranscriptMutation = useMutation<
+    ValidateListeningTranscriptResponse,
+    Error,
+    ValidateListeningTranscriptPayload
+  >({
+    mutationFn: (payload) => validateListeningTranscript(payload),
+  });
+
+  const coverageEntries = React.useMemo(() => {
+    if (selectedWordChips.length === 0) return [] as Array<{ word: string; covered: boolean }>;
+    return selectedWordChips.map((word) => {
+      const normalized = word.text.trim();
+      const lower = normalized.toLowerCase();
+      const covered = Boolean(
+        wordCoverage[normalized] ?? wordCoverage[lower] ?? wordCoverage[word.text] ?? false,
+      );
+      return { word: normalized, covered };
+    });
+  }, [selectedWordChips, wordCoverage]);
+
+  const coverageSatisfied = React.useMemo(
+    () => coverageEntries.length > 0 && coverageEntries.every(entry => entry.covered),
+    [coverageEntries],
+  );
+
+  const formattedEstimatedDuration = React.useMemo(() => {
+    if (estimatedDurationSec == null) return null;
+    const mins = Math.floor(estimatedDurationSec / 60);
+    const secs = Math.max(0, estimatedDurationSec % 60);
+    return `${mins}:${secs.toString().padStart(2, '0')}`;
+  }, [estimatedDurationSec]);
+
+  const highlightedTranscript = React.useMemo(() => {
+    if (!transcriptDraft) {
+      return [] as React.ReactNode[];
+    }
+
+    const escapeRegExp = (value: string) => value.replace(/([-\\^$*+?.()|[\]{}])/g, '\\$1');
+    const uniqueWords = Array.from(
+      new Set(
+        selectedWordChips
+          .map((word) => word.text.trim())
+          .filter((word) => word.length > 0),
+      ),
+    );
+
+    if (uniqueWords.length === 0) {
+      return [transcriptDraft];
+    }
+
+    const pattern = new RegExp(
+      uniqueWords
+        .sort((a, b) => b.length - a.length)
+        .map((word) => escapeRegExp(word))
+        .join('|'),
+      'gi',
+    );
+
+    const nodes: React.ReactNode[] = [];
+    let lastIndex = 0;
+    let match: RegExpExecArray | null;
+
+    while ((match = pattern.exec(transcriptDraft)) !== null) {
+      if (match.index > lastIndex) {
+        nodes.push(transcriptDraft.slice(lastIndex, match.index));
+      }
+
+      const matchedText = match[0];
+      nodes.push(
+        <Box
+          key={`hit-${match.index}-${matchedText}-${nodes.length}`}
+          component="strong"
+          sx={{ fontWeight: 700, color: '#1d4ed8' }}
+        >
+          {matchedText}
+        </Box>,
+      );
+
+      lastIndex = match.index + matchedText.length;
+    }
+
+    if (lastIndex < transcriptDraft.length) {
+      nodes.push(transcriptDraft.slice(lastIndex));
+    }
+
+    if (nodes.length === 0) {
+      return [transcriptDraft];
+    }
+
+    return nodes;
+  }, [selectedWordChips, transcriptDraft]);
+
+  React.useEffect(() => {
+    if (isListeningTask) {
+      setSourceKind('GENERATED_AUDIO');
+    } else if (sourceKind === 'GENERATED_AUDIO') {
+      setSourceKind('EXTERNAL_URL');
+    }
+  }, [isListeningTask, sourceKind]);
+
+  React.useEffect(() => {
+    if (!isListeningTask) {
+      setTranscriptId(null);
+      setTranscriptDraft('');
+      setWordCoverage({});
+      setCoverageMissing([]);
+      setEstimatedDurationSec(null);
+      setTranscriptError(null);
+      setTranscriptInfo(null);
+      setHasUnsavedTranscriptEdits(false);
+      setAudioContentRef(null);
+    }
+  }, [isListeningTask]);
+
+  React.useEffect(() => {
+    if (!isListeningTask || transcriptId) return;
+    setTranscriptMetadata({
+      language: listeningLanguage,
+      theme: listeningTheme || undefined,
+      cefr: listeningCefr,
+      style: listeningStyle,
+    });
+  }, [isListeningTask, transcriptId, listeningLanguage, listeningTheme, listeningCefr, listeningStyle]);
+
+  const buildCoverageMissing = (coverage: Record<string, boolean> | undefined) =>
+    Object.entries(coverage ?? {})
+      .filter(([, covered]) => !covered)
+      .map(([word]) => word);
+
+  const handleGenerateTranscript = async () => {
+    setTranscriptError(null);
+    setTranscriptInfo(null);
+
+    if (!isListeningTask) return;
+
+    if (!listeningWordRequirementMet) {
+      setTranscriptError('Select at least 3 focus words to guide the story.');
+      return;
+    }
+
+    const payload: GenerateListeningTranscriptPayload = {
+      wordIds: listeningWordIds,
+      durationSecTarget: listeningDurationSecTarget,
+      theme: listeningTheme || undefined,
+      cefr: listeningCefr || undefined,
+      language: listeningLanguage || undefined,
+      style: listeningStyle || undefined,
+      constraints: listeningMustIncludeAll ? { mustIncludeAllWords: true } : undefined,
+    };
+
+    if (listeningSeed.trim()) {
+      const parsedSeed = Number(listeningSeed.trim());
+      if (Number.isNaN(parsedSeed)) {
+        setTranscriptError('Seed must be a number.');
+        return;
+      }
+      payload.seed = parsedSeed;
+    }
+
+    try {
+      const result = await generateTranscriptMutation.mutateAsync(payload);
+      setTranscriptId(result.transcriptId);
+      setTranscriptDraft(result.transcript ?? '');
+      setWordCoverage(result.wordCoverage ?? {});
+      setCoverageMissing(buildCoverageMissing(result.wordCoverage));
+      setEstimatedDurationSec(result.estimatedDurationSec ?? null);
+      setTranscriptMetadata(
+        result.metadata ?? {
+          language: listeningLanguage,
+          theme: listeningTheme || undefined,
+          cefr: listeningCefr,
+          style: listeningStyle,
+        },
+      );
+      setHasUnsavedTranscriptEdits(false);
+      setTranscriptInfo('Transcript generated. Tweak the draft if needed, then save.');
+    } catch (error) {
+      console.error('Failed to generate transcript', error);
+      setTranscriptError(
+        error instanceof Error ? error.message : 'Failed to generate transcript. Please try again.',
+      );
+    }
+  };
+
+  const handleSaveTranscript = async () => {
+    if (!transcriptId) return;
+
+    setTranscriptError(null);
+    setTranscriptInfo(null);
+
+    try {
+      const result = await updateTranscriptMutation.mutateAsync({
+        transcriptId,
+        transcript: transcriptDraft.trim(),
+      });
+      setTranscriptDraft(result.transcript ?? transcriptDraft);
+      setWordCoverage(result.wordCoverage ?? {});
+      setCoverageMissing(buildCoverageMissing(result.wordCoverage));
+      setEstimatedDurationSec(result.estimatedDurationSec ?? estimatedDurationSec);
+      setTranscriptMetadata(result.metadata ?? transcriptMetadata);
+      setHasUnsavedTranscriptEdits(false);
+      setTranscriptInfo('Transcript saved.');
+    } catch (error) {
+      console.error('Failed to save transcript', error);
+      setTranscriptError(
+        error instanceof Error ? error.message : 'Could not save transcript. Please try again.',
+      );
+    }
+  };
+
+  const handleValidateTranscript = async () => {
+    setTranscriptError(null);
+    setTranscriptInfo(null);
+
+    if (!transcriptDraft.trim()) {
+      setTranscriptError('Transcript text cannot be empty.');
+      return;
+    }
+
+    if (!listeningWordRequirementMet) {
+      setTranscriptError('Make sure you selected enough vocabulary words before validating.');
+      return;
+    }
+
+    try {
+      const result = await validateTranscriptMutation.mutateAsync({
+        transcript: transcriptDraft,
+        wordIds: listeningWordIds,
+      });
+      setWordCoverage(result.wordCoverage ?? {});
+      setCoverageMissing(buildCoverageMissing(result.wordCoverage));
+      setTranscriptInfo(
+        result.missing.length === 0
+          ? 'Every target word is present. Ready for audio!'
+          : 'Some words are still missing. Consider tweaking the text.',
+      );
+    } catch (error) {
+      console.error('Failed to validate transcript', error);
+      setTranscriptError(
+        error instanceof Error ? error.message : 'Validation failed. Try again in a moment.',
+      );
+    }
+  };
+
   const isValid = React.useMemo(() => {
     if (!studentId || !title.trim()) return false;
     if (isVocabList) {
-      return selectedWordIds.length >= 5 && selectedWordIds.length <= 100;
+      return !isVocabSelectionInvalid;
+    }
+    if (isListeningTask) {
+      if (
+        !transcriptId ||
+        hasUnsavedTranscriptEdits ||
+        !listeningWordRequirementMet ||
+        !audioContentRef
+      ) {
+        return false;
+      }
+      return true;
     }
     if (sourceKind === 'EXTERNAL_URL') {
       return urlValid;
     }
-    // other combinations considered valid for now (MATERIAL/LESSON_CONTENT pickers are future work)
     return true;
-  }, [studentId, title, isVocabList, selectedWordIds.length, sourceKind, urlValid]);
+  }, [
+    studentId,
+    title,
+    isVocabList,
+    isVocabSelectionInvalid,
+    isListeningTask,
+    transcriptId,
+    hasUnsavedTranscriptEdits,
+    listeningWordRequirementMet,
+    audioContentRef,
+    sourceKind,
+    urlValid,
+  ]);
 
   const handlePasteFromClipboard = async () => {
     try {
@@ -191,6 +577,45 @@ const HomeworkComposerDrawer: React.FC<HomeworkComposerDrawerProps> = ({ open, o
         contentRef: { wordIds: selectedWordIds, settings },
         vocabWordIds: selectedWordIds,
       });
+    } else if (isListeningTask && transcriptId && audioContentRef) {
+      const generatorParams = {
+        wordIds: listeningWordIds,
+        durationSecTarget: listeningDurationSecTarget,
+        theme: listeningTheme || undefined,
+        cefr: listeningCefr || undefined,
+        language: listeningLanguage || undefined,
+        style: listeningStyle || undefined,
+        constraints: listeningMustIncludeAll ? { mustIncludeAllWords: true } : undefined,
+        seed: listeningSeed.trim() ? Number(listeningSeed.trim()) : undefined,
+      };
+
+      const durationSec = audioContentRef?.durationSec ?? estimatedDurationSec ?? listeningDurationSecTarget;
+      const transcriptText = audioContentRef?.transcript ?? transcriptDraft.trim();
+
+      const listeningContentRef = {
+        generatorRequestId: audioContentRef.generatorRequestId,
+        audioMaterialId: audioContentRef.audioMaterialId,
+        audioUrl: audioContentRef.audioUrl,
+        transcriptId,
+        transcript: transcriptText,
+        durationSec,
+        wordIds: listeningWordIds,
+        theme: audioContentRef.theme ?? (listeningTheme || undefined),
+        cefr: audioContentRef.cefr ?? (listeningCefr || undefined),
+        metadata: transcriptMetadata,
+        wordCoverage,
+        generatorParams,
+        voiceId: audioContentRef.voiceId,
+      };
+
+      tasks.push({
+        title: taskTitle,
+        type: 'LISTENING',
+        sourceKind: 'GENERATED_AUDIO',
+        instructions: undefined,
+        contentRef: listeningContentRef,
+        vocabWordIds: selectedWordIds,
+      });
     } else {
       tasks.push({
         title: taskTitle,
@@ -205,6 +630,32 @@ const HomeworkComposerDrawer: React.FC<HomeworkComposerDrawerProps> = ({ open, o
 
   const submit = async (openAfterCreate: boolean) => {
     if (!user?.id || !isValid) return;
+
+    if (isListeningTask) {
+      setTranscriptError(null);
+      setTranscriptInfo(null);
+
+      if (!transcriptId) {
+        setTranscriptError('Generate the transcript before creating the homework.');
+        return;
+      }
+
+      if (hasUnsavedTranscriptEdits) {
+        setTranscriptError('Save your transcript edits before continuing.');
+        return;
+      }
+
+      if (!listeningWordRequirementMet) {
+        setTranscriptError('Please verify the selected vocabulary before creating the task.');
+        return;
+      }
+
+      if (!audioContentRef) {
+        setTranscriptError('Generate audio for the transcript before saving this task.');
+        return;
+      }
+    }
+
     const payload: CreateAssignmentDto = {
       studentId,
       title,
@@ -293,12 +744,28 @@ const HomeworkComposerDrawer: React.FC<HomeworkComposerDrawerProps> = ({ open, o
             <Typography variant="h6" sx={{ mb: 2 }}>Task</Typography>
             <Stack gap={2}>
               {/*<TextField label="Task title" value={taskTitle} onChange={e => setTaskTitle(e.target.value)} fullWidth />*/}
-              <TextField select label="Task type" value={taskType} onChange={e => setTaskType(e.target.value as HomeworkTaskType)}>
-                {['VOCAB'].map(t => (<MenuItem key={t} value={t}>{t}</MenuItem>))}
+              <TextField
+                select
+                label="Task type"
+                value={taskType}
+                onChange={e => setTaskType(e.target.value as HomeworkTaskType)}
+              >
+                {taskTypeOptions.map(t => (<MenuItem key={t} value={t}>{t}</MenuItem>))}
               </TextField>
-              <TextField select label="Source kind" value={sourceKind} onChange={e => setSourceKind(e.target.value as SourceKind)}>
-                {['VOCAB_LIST'].map(s => (<MenuItem key={s} value={s}>{s}</MenuItem>))}
-              </TextField>
+              {!isListeningTask ? (
+                <TextField
+                  select
+                  label="Source kind"
+                  value={sourceKind}
+                  onChange={e => setSourceKind(e.target.value as SourceKind)}
+                >
+                  {sourceKindOptions
+                    .filter(s => s !== 'GENERATED_AUDIO')
+                    .map(s => (<MenuItem key={s} value={s}>{s}</MenuItem>))}
+                </TextField>
+              ) : (
+                <TextField label="Source kind" value="GENERATED_AUDIO" InputProps={{ readOnly: true }} disabled />
+              )}
 
               {sourceKind === 'EXTERNAL_URL' && (
                 <Stack direction="row" gap={1} alignItems="center">
@@ -307,12 +774,24 @@ const HomeworkComposerDrawer: React.FC<HomeworkComposerDrawerProps> = ({ open, o
                 </Stack>
               )}
 
-              {isVocabList && (
-                <Stack gap={1} sx={{ mt: 1 }}>
+              {(isVocabList || isListeningTask) && (
+                <Stack gap={isListeningTask ? 2 : 1} sx={{ mt: 1 }}>
                   <Stack direction="row" gap={1} alignItems="center">
-                    <Button variant="outlined" onClick={() => setPickerOpen(true)}>Select words</Button>
-                    <Chip size="small" color={selectedWordIds.length >= 5 ? 'success' : 'warning'} label={`${selectedWordIds.length} selected`} />
-                    <Typography variant="caption" color="text.secondary">Choose 5–100 words</Typography>
+                    <Button variant="outlined" onClick={() => setPickerOpen(true)}>
+                      {isListeningTask ? 'Pick focus words' : 'Select words'}
+                    </Button>
+                    <Chip
+                      size="small"
+                      color={
+                        isVocabList
+                          ? (!isVocabSelectionInvalid ? 'success' : 'warning')
+                          : (listeningWordRequirementMet ? 'success' : 'warning')
+                      }
+                      label={`${selectedWordIds.length} selected`}
+                    />
+                    <Typography variant="caption" color="text.secondary">
+                      {isVocabList ? 'Choose 5–100 words' : 'Pick 3+ words to anchor the transcript'}
+                    </Typography>
                   </Stack>
                   {selectedWordChips.length > 0 && (
                     <Stack direction="row" gap={1} useFlexGap flexWrap="wrap">
@@ -324,16 +803,203 @@ const HomeworkComposerDrawer: React.FC<HomeworkComposerDrawerProps> = ({ open, o
                       )}
                     </Stack>
                   )}
-                  {(selectedWordIds.length < 5 || selectedWordIds.length > 100) && (
+                  {isVocabList && isVocabSelectionInvalid && (
                     <Typography variant="caption" color="error">Please select between 5 and 100 words.</Typography>
                   )}
-                  <TextField type="number" label="Mastery streak" value={masteryStreak}
-                             onChange={e => setMasteryStreak(Math.max(1, Math.min(10, Number(e.target.value) || 0)))}
-                             InputLabelProps={{ shrink: true }} inputProps={{ min: 1, max: 10 }} />
-                  {/*<FormControlLabel control={<Checkbox checked={shuffle} onChange={(e)=> setShuffle(e.target.checked)} />} label="Shuffle words" />*/}
-     {/*             <TextField type="number" label="Time limit (minutes)" value={timeLimitMin}
-                             onChange={e => setTimeLimitMin(e.target.value)} InputLabelProps={{ shrink: true }}
-                             helperText="Optional" />*/}
+                  {isListeningTask && !listeningWordRequirementMet && (
+                    <Typography variant="caption" color="error">
+                      Please select at least 3 words to proceed.
+                    </Typography>
+                  )}
+
+                  {isVocabList && (
+                    <TextField
+                      type="number"
+                      label="Mastery streak"
+                      value={masteryStreak}
+                      onChange={e => setMasteryStreak(Math.max(1, Math.min(10, Number(e.target.value) || 0)))}
+                      InputLabelProps={{ shrink: true }}
+                      inputProps={{ min: 1, max: 10 }}
+                    />
+                  )}
+
+                  {isListeningTask && (
+                    <>
+                      <Divider flexItem sx={{ borderStyle: 'dashed', opacity: 0.6 }} />
+
+                      <Stack gap={1.5}>
+                        <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>Generation preferences</Typography>
+                        <Box>
+                          <Typography variant="caption" sx={{ color: 'text.secondary', fontWeight: 500 }} gutterBottom>
+                            Target duration
+                          </Typography>
+                          <Slider
+                            value={listeningDurationSecTarget}
+                            onChange={(_, value) => setListeningDurationSecTarget(Array.isArray(value) ? value[0] : value)}
+                            min={45}
+                            max={150}
+                            step={15}
+                            marks={durationMarks}
+                            valueLabelDisplay="on"
+                            valueLabelFormat={(value) => formatDurationLabel(value as number)}
+                            sx={{ px: 1 }}
+                          />
+                        </Box>
+                        <TextField
+                          fullWidth
+                          label="Theme"
+                          placeholder="Wildlife conservation"
+                          value={listeningTheme}
+                          onChange={(e) => setListeningTheme(e.target.value)}
+                        />
+                      </Stack>
+
+                      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+                        <TextField select label="Language" value={listeningLanguage} onChange={(e) => setListeningLanguage(e.target.value)} fullWidth>
+                          {languageOptions.map(lang => <MenuItem key={lang} value={lang}>{lang}</MenuItem>)}
+                        </TextField>
+                        <TextField select label="CEFR" value={listeningCefr} onChange={(e) => setListeningCefr(e.target.value)} fullWidth>
+                          {cefrOptions.map(level => <MenuItem key={level} value={level}>{level}</MenuItem>)}
+                        </TextField>
+                      </Stack>
+
+                      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+                        <TextField select label="Narration style" value={listeningStyle} onChange={(e) => setListeningStyle(e.target.value)} fullWidth>
+                          {styleOptions.map(style => <MenuItem key={style} value={style}>{style}</MenuItem>)}
+                        </TextField>
+                        <TextField
+                          label="Seed (optional)"
+                          value={listeningSeed}
+                          onChange={(e) => {
+                            const val = e.target.value;
+                            if (/^-?\d*$/.test(val)) {
+                              setListeningSeed(val);
+                            }
+                          }}
+                          placeholder="42"
+                          inputProps={{ inputMode: 'numeric', pattern: '-?[0-9]*' }}
+                          fullWidth
+                        />
+                      </Stack>
+
+                      <FormControlLabel
+                        control={<Checkbox checked={listeningMustIncludeAll} onChange={(e) => setListeningMustIncludeAll(e.target.checked)} />}
+                        label="Force every selected word to appear"
+                      />
+
+                      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems={{ xs: 'stretch', sm: 'center' }}>
+                        <Button
+                          variant="contained"
+                          onClick={handleGenerateTranscript}
+                          disabled={generateTranscriptMutation.isPending}
+                          sx={{ minWidth: 200 }}
+                        >
+                          {generateTranscriptMutation.isPending ? <CircularProgress size={18} sx={{ color: 'white' }} /> : 'Generate transcript'}
+                        </Button>
+                        <Button
+                          variant="outlined"
+                          onClick={handleValidateTranscript}
+                          disabled={validateTranscriptMutation.isPending || !transcriptDraft}
+                        >
+                          {validateTranscriptMutation.isPending ? <CircularProgress size={18} /> : 'Validate coverage'}
+                        </Button>
+                        <Button
+                          variant="outlined"
+                          color="success"
+                          onClick={handleSaveTranscript}
+                          disabled={!transcriptId || !hasUnsavedTranscriptEdits || updateTranscriptMutation.isPending}
+                        >
+                          {updateTranscriptMutation.isPending ? <CircularProgress size={18} /> : 'Save edits'}
+                        </Button>
+                      </Stack>
+
+                      {transcriptError && <Alert severity="error">{transcriptError}</Alert>}
+                      {transcriptInfo && <Alert severity="info">{transcriptInfo}</Alert>}
+
+                      <Stack spacing={1.5}>
+                        <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>Transcript draft</Typography>
+                        <TextField
+                          value={transcriptDraft}
+                          onChange={(e) => {
+                            setTranscriptDraft(e.target.value);
+                            setHasUnsavedTranscriptEdits(true);
+                          }}
+                          multiline
+                          minRows={5}
+                          placeholder="The rainforest is a vibrant, sustainable habitat..."
+                        />
+                        {transcriptDraft && (
+                          <Box
+                            sx={{
+                              borderRadius: 2,
+                              border: '1px solid rgba(37,115,255,0.16)',
+                              bgcolor: 'rgba(37,115,255,0.04)',
+                              px: 2,
+                              py: 1.5,
+                            }}
+                          >
+                            <Typography variant="overline" sx={{ letterSpacing: 1, color: '#1d4ed8' }}>
+                              Preview with highlighted words
+                            </Typography>
+                            <Typography
+                              variant="body2"
+                              sx={{ whiteSpace: 'pre-wrap', lineHeight: 1.6, color: '#1a1c1f' }}
+                            >
+                              {highlightedTranscript}
+                            </Typography>
+                          </Box>
+                        )}
+                        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems={{ xs: 'flex-start', sm: 'center' }}>
+                          {formattedEstimatedDuration && (
+                            <Typography variant="body2" color="text.secondary">
+                              Estimated runtime: {formattedEstimatedDuration}
+                            </Typography>
+                          )}
+                          {transcriptId && (
+                            <Typography variant="body2" color="text.secondary">
+                              Draft saved as #{transcriptId.slice(0, 8)}
+                            </Typography>
+                          )}
+                        </Stack>
+                      {coverageEntries.length > 0 && (
+                        <Stack spacing={0.5}>
+                          <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>Word coverage</Typography>
+                          <Stack spacing={0.5}>
+                            {coverageEntries.map(entry => (
+                                <Typography key={entry.word} variant="body2" sx={{ color: entry.covered ? '#047857' : '#b91c1c' }}>
+                                  {entry.covered ? '✔︎' : '✕'} {entry.word}
+                                </Typography>
+                              ))}
+                            </Stack>
+                            {coverageMissing.length > 0 && (
+                              <Typography variant="caption" color="error">
+                                Missing: {coverageMissing.join(', ')}
+                              </Typography>
+                          )}
+                        </Stack>
+                      )}
+
+                      <ListeningAudioGenerationPanel
+                        transcriptId={transcriptId}
+                        transcriptText={transcriptDraft}
+                        metadata={transcriptMetadata}
+                        wordIds={listeningWordIds}
+                        coverageSatisfied={coverageSatisfied}
+                        disabled={!transcriptId}
+                        languageCode={listeningLanguage}
+                        theme={listeningTheme || undefined}
+                        cefr={listeningCefr || undefined}
+                        hasUnsavedTranscriptEdits={hasUnsavedTranscriptEdits}
+                        onAudioContentChange={(content) => setAudioContentRef(content)}
+                        onDurationUpdate={(duration) => {
+                          if (duration != null) {
+                            setEstimatedDurationSec(duration);
+                          }
+                        }}
+                      />
+                    </Stack>
+                  </>
+                )}
                 </Stack>
               )}
             </Stack>
@@ -352,7 +1018,7 @@ const HomeworkComposerDrawer: React.FC<HomeworkComposerDrawerProps> = ({ open, o
 
       {/* Nested vocabulary selector dialog */}
       <Dialog open={pickerOpen} onClose={() => setPickerOpen(false)} fullWidth maxWidth="md">
-        <DialogTitle>Select vocabulary words</DialogTitle>
+        <DialogTitle>{isListeningTask ? 'Select focus words' : 'Select vocabulary words'}</DialogTitle>
         <DialogContent>
           <Stack gap={2} sx={{ mt: 1 }}>
             <TextField label="Search" value={wordSearch} onChange={e => setWordSearch(e.target.value)} fullWidth />

--- a/src/components/listening/ListeningAudioGenerationPanel.tsx
+++ b/src/components/listening/ListeningAudioGenerationPanel.tsx
@@ -1,0 +1,764 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Collapse,
+  Divider,
+  IconButton,
+  Paper,
+  Radio,
+  Slider,
+  Stack,
+  Switch,
+  TextField,
+  Typography,
+} from '@mui/material';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import StopIcon from '@mui/icons-material/Stop';
+import ReplayIcon from '@mui/icons-material/Replay';
+import VolumeUpIcon from '@mui/icons-material/VolumeUp';
+import GraphicEqIcon from '@mui/icons-material/GraphicEq';
+import { useSnackbar } from 'notistack';
+import { useQuery } from '@tanstack/react-query';
+import { useAuth } from '../../context/AuthContext';
+import {
+  getListeningAudioJobStatus,
+  listListeningVoices,
+  startListeningAudioGeneration,
+} from '../../services/api';
+import type {
+  ListeningAudioJobStartResponse,
+  ListeningAudioJobStatus,
+  ListeningAudioJobStatusResponse,
+  ListeningGeneratedAudioContentRef,
+  ListeningTranscriptMetadata,
+  ListeningVoice,
+  ListeningVoiceSettings,
+  StartListeningAudioJobPayload,
+} from '../../types';
+
+const DEFAULT_VOICE_SETTINGS: ListeningVoiceSettings = {
+  stability: 0.4,
+  similarity_boost: 0.7,
+  style: 0.2,
+  speed: 1.0,
+  use_speaker_boost: true,
+};
+
+const MAX_WAIT_MS = 90_000;
+const POLL_DELAYS_MS = [1_000, 2_000, 4_000, 5_000];
+
+const generateKey = () => {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2);
+};
+
+const isTerminalStatus = (status: ListeningAudioJobStatus | undefined | null) =>
+  status === 'SUCCEEDED' || status === 'FAILED' || status === 'CANCELLED' || status === 'EXPIRED';
+
+const normalizeTranscript = (value: string) => value.trim().replace(/\s+/g, ' ');
+
+interface PersistedJobState {
+  jobId: string;
+  idempotencyKey: string;
+  voiceId: string;
+  voiceSettings: ListeningVoiceSettings;
+  transcript: string;
+  startedAt: number;
+}
+
+export interface ListeningAudioGenerationPanelProps {
+  transcriptId: string | null;
+  transcriptText: string;
+  metadata?: ListeningTranscriptMetadata;
+  wordIds: string[];
+  coverageSatisfied: boolean;
+  disabled?: boolean;
+  languageCode?: string;
+  theme?: string;
+  cefr?: string;
+  hasUnsavedTranscriptEdits: boolean;
+  onAudioContentChange: (content: ListeningGeneratedAudioContentRef | null) => void;
+  onDurationUpdate?: (durationSec: number | null) => void;
+  onStatusChange?: (status: ListeningAudioJobStatus | null) => void;
+}
+
+const ListeningAudioGenerationPanel: React.FC<ListeningAudioGenerationPanelProps> = ({
+  transcriptId,
+  transcriptText,
+  metadata,
+  wordIds,
+  coverageSatisfied,
+  disabled,
+  languageCode,
+  theme,
+  cefr,
+  hasUnsavedTranscriptEdits,
+  onAudioContentChange,
+  onDurationUpdate,
+  onStatusChange,
+}) => {
+  const { token } = useAuth();
+  const { enqueueSnackbar } = useSnackbar();
+
+  const [search, setSearch] = useState('');
+  const [selectedVoiceId, setSelectedVoiceId] = useState<string>('');
+  const [voiceSettings, setVoiceSettings] = useState<ListeningVoiceSettings>(DEFAULT_VOICE_SETTINGS);
+  const [idempotencyKey, setIdempotencyKey] = useState<string>(generateKey());
+  const [job, setJob] = useState<ListeningAudioJobStatusResponse | null>(null);
+  const [jobError, setJobError] = useState<string | null>(null);
+  const [needsRegeneration, setNeedsRegeneration] = useState(false);
+  const [audioContent, setAudioContent] = useState<ListeningGeneratedAudioContentRef | null>(null);
+  const [transcriptUsed, setTranscriptUsed] = useState<string | null>(null);
+  const [pollIndex, setPollIndex] = useState(0);
+  const [jobStartedAt, setJobStartedAt] = useState<number | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [documentHidden, setDocumentHidden] = useState<boolean>(false);
+  const bannerRef = useRef<HTMLDivElement | null>(null);
+  const previewAudioRef = useRef<HTMLAudioElement | null>(null);
+  const previewingVoiceRef = useRef<string | null>(null);
+  const lastProgressStatus = useRef<ListeningAudioJobStatus | null>(null);
+  const lastTranscriptProp = useRef<string>('');
+  const previousStorageKeyRef = useRef<string | null>(null);
+
+  const storageKey = useMemo(() => (transcriptId ? `listeningAudioJob:${transcriptId}` : null), [transcriptId]);
+
+  const voicesQuery = useQuery({
+    queryKey: ['listening-voices'],
+    queryFn: () => listListeningVoices(),
+    staleTime: 24 * 60 * 60 * 1000,
+  });
+
+  const voices = voicesQuery.data ?? [];
+
+  useEffect(() => {
+    if (!selectedVoiceId && voices.length > 0) {
+      setSelectedVoiceId(voices[0].voiceId);
+      if (voices[0].settings) {
+        setVoiceSettings((prev) => ({ ...prev, ...voices[0].settings }));
+      }
+    }
+  }, [voices, selectedVoiceId]);
+
+  const filteredVoices = useMemo(() => {
+    if (!search.trim()) return voices;
+    const q = search.trim().toLowerCase();
+    return voices.filter((voice) => voice.name.toLowerCase().includes(q));
+  }, [voices, search]);
+
+  const persistJobState = useCallback(
+    (state: PersistedJobState | null) => {
+      if (!storageKey || typeof window === 'undefined') return;
+      if (!state) {
+        sessionStorage.removeItem(storageKey);
+      } else {
+        sessionStorage.setItem(storageKey, JSON.stringify(state));
+      }
+    },
+    [storageKey],
+  );
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (previousStorageKeyRef.current && previousStorageKeyRef.current !== storageKey) {
+      sessionStorage.removeItem(previousStorageKeyRef.current);
+    }
+    previousStorageKeyRef.current = storageKey;
+  }, [storageKey]);
+
+  // Resume any persisted job state when transcriptId changes
+  useEffect(() => {
+    if (!storageKey || typeof window === 'undefined') {
+      setJob(null);
+      setAudioContent(null);
+      setTranscriptUsed(null);
+      return;
+    }
+
+    const raw = sessionStorage.getItem(storageKey);
+    if (!raw) {
+      setJob(null);
+      setAudioContent(null);
+      setTranscriptUsed(null);
+      return;
+    }
+
+    try {
+      const saved: PersistedJobState = JSON.parse(raw);
+      if (saved.idempotencyKey) setIdempotencyKey(saved.idempotencyKey);
+      if (saved.voiceId) setSelectedVoiceId(saved.voiceId);
+      if (saved.voiceSettings) setVoiceSettings((prev) => ({ ...prev, ...saved.voiceSettings }));
+      setJobStartedAt(saved.startedAt || Date.now());
+      if (saved.jobId) {
+        getListeningAudioJobStatus(saved.jobId)
+          .then((status) => {
+            setJob(status);
+            if (status.status === 'SUCCEEDED' && status.audioUrl && status.audioMaterialId && status.transcript) {
+              const durationSec = status.durationSec ?? null;
+              if (durationSec != null) {
+                onDurationUpdate?.(durationSec);
+              }
+              const content: ListeningGeneratedAudioContentRef = {
+                sourceKind: 'GENERATED_AUDIO',
+                generatorRequestId: status.jobId,
+                audioMaterialId: status.audioMaterialId,
+                audioUrl: status.audioUrl,
+                transcript: status.transcript,
+                durationSec: status.durationSec ?? 0,
+                wordIds,
+                theme: theme ?? metadata?.theme,
+                cefr: cefr ?? metadata?.cefr,
+                metadata,
+                voiceId: saved.voiceId,
+              };
+              setAudioContent(content);
+              setTranscriptUsed(normalizeTranscript(status.transcript));
+              onAudioContentChange(content);
+              persistJobState(null);
+            } else if (status.status && !isTerminalStatus(status.status)) {
+              setJobStartedAt(saved.startedAt || Date.now());
+            } else if (status.status === 'FAILED') {
+              setJobError(status.message || status.error || 'Audio generation failed.');
+            }
+          })
+          .catch(() => {
+            setJob(null);
+            persistJobState(null);
+          });
+      }
+    } catch {
+      persistJobState(null);
+      setJob(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [storageKey]);
+
+  // Track document visibility for adaptive polling
+  useEffect(() => {
+    const handleVisibility = () => {
+      setDocumentHidden(document.visibilityState === 'hidden');
+    };
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => document.removeEventListener('visibilitychange', handleVisibility);
+  }, []);
+
+  const stopPreviewAudio = useCallback(() => {
+    if (previewAudioRef.current) {
+      previewAudioRef.current.pause();
+      previewAudioRef.current.currentTime = 0;
+    }
+    previewingVoiceRef.current = null;
+  }, []);
+
+  useEffect(() => () => stopPreviewAudio(), [stopPreviewAudio]);
+
+  const handlePreview = useCallback(
+    (voice: ListeningVoice) => {
+      if (!voice.previewUrl) return;
+
+      if (!previewAudioRef.current) {
+        previewAudioRef.current = new Audio();
+      }
+
+      const audio = previewAudioRef.current;
+      if (previewingVoiceRef.current === voice.voiceId) {
+        stopPreviewAudio();
+        return;
+      }
+
+      audio.src = voice.previewUrl;
+      audio.play().catch(() => {
+        enqueueSnackbar('Unable to play preview. Please check your audio output.', { variant: 'warning' });
+      });
+      previewingVoiceRef.current = voice.voiceId;
+      audio.onended = () => {
+        previewingVoiceRef.current = null;
+      };
+    },
+    [enqueueSnackbar, stopPreviewAudio],
+  );
+
+  const resetAudioState = useCallback(
+    (resetSelection = false) => {
+      setJob(null);
+      setJobError(null);
+      setAudioContent(null);
+      setTranscriptUsed(null);
+      setNeedsRegeneration(false);
+      setPollIndex(0);
+      setJobStartedAt(null);
+      onAudioContentChange(null);
+      onStatusChange?.(null);
+      if (resetSelection) {
+        setIdempotencyKey(generateKey());
+      }
+      if (storageKey) {
+        persistJobState(null);
+      }
+    },
+    [onAudioContentChange, onStatusChange, persistJobState, storageKey],
+  );
+
+  // Invalidate generated audio when transcript changes meaningfully
+  useEffect(() => {
+    const normalized = normalizeTranscript(transcriptText);
+    if (!audioContent) {
+      lastTranscriptProp.current = normalized;
+      return;
+    }
+    if (transcriptUsed && normalized !== transcriptUsed) {
+      setNeedsRegeneration(true);
+      onAudioContentChange(null);
+    } else if (needsRegeneration && transcriptUsed && normalized === transcriptUsed) {
+      setNeedsRegeneration(false);
+      onAudioContentChange(audioContent);
+    }
+    lastTranscriptProp.current = normalized;
+  }, [audioContent, transcriptText, transcriptUsed, needsRegeneration, onAudioContentChange]);
+
+  useEffect(() => {
+    if (!hasUnsavedTranscriptEdits) return;
+    if (audioContent) {
+      setNeedsRegeneration(true);
+      onAudioContentChange(null);
+    }
+  }, [hasUnsavedTranscriptEdits, audioContent, onAudioContentChange]);
+
+  // Poll job status until terminal state
+  useEffect(() => {
+    if (!job || !job.jobId || isTerminalStatus(job.status)) {
+      return undefined;
+    }
+
+    const delay = documentHidden ? Math.max(POLL_DELAYS_MS[pollIndex] ?? 5_000, 5_000) : POLL_DELAYS_MS[pollIndex] ?? 5_000;
+
+    const timeout = window.setTimeout(async () => {
+      try {
+        const status = await getListeningAudioJobStatus(job.jobId);
+        setJob(status);
+      } catch (error) {
+        console.error('Failed to poll audio job', error);
+        setJobError('Lost connection while polling audio job. Retrying...');
+      }
+    }, delay);
+
+    return () => window.clearTimeout(timeout);
+  }, [job, pollIndex, documentHidden]);
+
+  // Handle job transitions
+  useEffect(() => {
+    const status = job?.status ?? null;
+    if (status && status !== lastProgressStatus.current) {
+      onStatusChange?.(status);
+      lastProgressStatus.current = status;
+      if (bannerRef.current) {
+        bannerRef.current.focus({ preventScroll: false });
+      }
+    }
+
+    if (!job || !job.jobId) return;
+
+    if (!jobStartedAt) {
+      setJobStartedAt(Date.now());
+    }
+
+    if (!status) return;
+
+    if (!isTerminalStatus(status)) {
+      setPollIndex((prev) => Math.min(prev + 1, POLL_DELAYS_MS.length - 1));
+      if (jobStartedAt && Date.now() - jobStartedAt > MAX_WAIT_MS) {
+        setJob({ ...job, status: 'FAILED' });
+        setJobError('Audio generation timed out. Please try again.');
+        enqueueSnackbar('Audio generation timed out. Try again.', { variant: 'error' });
+        persistJobState(null);
+      }
+      return;
+    }
+
+    if (status === 'SUCCEEDED') {
+      if (job.audioMaterialId && job.audioUrl && job.transcript) {
+        const normalizedTranscript = normalizeTranscript(job.transcript);
+        const durationSec = job.durationSec ?? null;
+        if (durationSec != null) {
+          onDurationUpdate?.(durationSec);
+        }
+        const content: ListeningGeneratedAudioContentRef = {
+          sourceKind: 'GENERATED_AUDIO',
+          generatorRequestId: job.jobId,
+          audioMaterialId: job.audioMaterialId,
+          audioUrl: job.audioUrl,
+          transcript: job.transcript,
+          durationSec: job.durationSec ?? 0,
+          wordIds,
+          theme: theme ?? metadata?.theme,
+          cefr: cefr ?? metadata?.cefr,
+          metadata,
+          voiceId: selectedVoiceId || undefined,
+        };
+        setAudioContent(content);
+        setTranscriptUsed(normalizedTranscript);
+        setNeedsRegeneration(false);
+        onAudioContentChange(content);
+        enqueueSnackbar('Audio ready! Review the preview below.', { variant: 'success' });
+      } else {
+        setJobError('Audio job completed without an audio asset.');
+        enqueueSnackbar('Audio generation completed but no audio was returned.', { variant: 'warning' });
+      }
+      persistJobState(null);
+      setIdempotencyKey(generateKey());
+    } else if (status === 'FAILED' || status === 'CANCELLED' || status === 'EXPIRED') {
+      const errorMessage = job.message || job.error || 'Audio generation failed. Please retry.';
+      setJobError(errorMessage);
+      enqueueSnackbar(errorMessage, { variant: 'error' });
+      persistJobState(null);
+      setIdempotencyKey(generateKey());
+    }
+  }, [job, enqueueSnackbar, metadata, onAudioContentChange, onDurationUpdate, onStatusChange, persistJobState, jobStartedAt, wordIds, theme, cefr, selectedVoiceId]);
+
+  const handleGenerateAudio = async () => {
+    if (!transcriptId || !transcriptText.trim()) {
+      enqueueSnackbar('Generate and save a transcript before creating audio.', { variant: 'warning' });
+      return;
+    }
+    if (!token) {
+      enqueueSnackbar('You need to be signed in to generate audio.', { variant: 'error' });
+      return;
+    }
+    if (!selectedVoiceId) {
+      enqueueSnackbar('Select a voice to continue.', { variant: 'warning' });
+      return;
+    }
+    if (!coverageSatisfied) {
+      enqueueSnackbar('Please ensure every focus word appears in the transcript.', { variant: 'warning' });
+      return;
+    }
+
+    stopPreviewAudio();
+    setIsSubmitting(true);
+    setJobError(null);
+
+    const payload: StartListeningAudioJobPayload = {
+      transcriptId,
+      transcriptOverride: transcriptText.trim(),
+      voiceId: selectedVoiceId,
+      ttsModel: 'eleven_multilingual_v2',
+      languageCode: (metadata?.language || languageCode || 'en-US') as string,
+      voiceSettings: {
+        ...DEFAULT_VOICE_SETTINGS,
+        ...voiceSettings,
+      },
+      outputFormat: 'mp3_44100_128',
+      metadata: {
+        ...(metadata || {}),
+        ...(theme ? { theme } : {}),
+        ...(cefr ? { cefr } : {}),
+      },
+    };
+
+    try {
+      const response: ListeningAudioJobStartResponse = await startListeningAudioGeneration(payload, token, idempotencyKey);
+      setJob({ jobId: response.jobId, status: response.status });
+      setJobStartedAt(Date.now());
+      setPollIndex(0);
+      setNeedsRegeneration(false);
+      onAudioContentChange(null);
+      onStatusChange?.(response.status);
+      persistJobState({
+        jobId: response.jobId,
+        idempotencyKey,
+        voiceId: selectedVoiceId,
+        voiceSettings,
+        transcript: normalizeTranscript(transcriptText),
+        startedAt: Date.now(),
+      });
+      enqueueSnackbar('Audio generation started. This may take up to a minute.', { variant: 'info' });
+    } catch (error: any) {
+      console.error('Failed to start audio generation', error);
+      const message = error?.response?.data?.message || error?.message || 'Unable to start audio generation.';
+      setJobError(message);
+      enqueueSnackbar(message, { variant: 'error' });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleRetry = () => {
+    setIdempotencyKey(generateKey());
+    resetAudioState(false);
+  };
+
+  const handleReplaceAudio = () => {
+    resetAudioState(true);
+  };
+
+  const canGenerate =
+    !disabled &&
+    !!transcriptId &&
+    !!transcriptText.trim() &&
+    !!selectedVoiceId &&
+    coverageSatisfied &&
+    !isSubmitting &&
+    !(job && !isTerminalStatus(job.status));
+
+  const currentStatus = job?.status ?? (audioContent ? 'SUCCEEDED' : null);
+
+  const showAdvancedHint = advancedOpen ? 'Hide advanced voice controls' : 'Show advanced voice controls';
+
+  return (
+    <Stack spacing={2} sx={{ mt: 3 }}>
+      <Divider flexItem sx={{ borderStyle: 'dashed', opacity: 0.6 }} />
+      <Stack direction="row" spacing={1} alignItems="center">
+        <GraphicEqIcon color="primary" fontSize="small" />
+        <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>Audio generation</Typography>
+      </Stack>
+      <Typography variant="body2" color="text.secondary">
+        Choose a narration voice, optionally tweak the delivery, then generate an MP3 preview for this listening task.
+      </Typography>
+
+      <Paper variant="outlined" sx={{ p: 2 }}>
+        <Stack spacing={2}>
+          <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems={{ xs: 'stretch', md: 'flex-start' }}>
+            <Stack spacing={1.5} flex={1}>
+              <Stack direction="row" spacing={1} alignItems="center">
+                <VolumeUpIcon fontSize="small" color="action" />
+                <Typography variant="subtitle2">Voice</Typography>
+              </Stack>
+              <TextField
+                size="small"
+                label="Search voices"
+                value={search}
+                onChange={(event) => setSearch(event.target.value)}
+                placeholder="Type to filter"
+              />
+              <Stack spacing={1} sx={{ maxHeight: 240, overflowY: 'auto', pr: 1 }}>
+                {filteredVoices.map((voice) => {
+                  const isSelected = voice.voiceId === selectedVoiceId;
+                  const isPreviewing = previewingVoiceRef.current === voice.voiceId;
+                  return (
+                    <Paper
+                      key={voice.voiceId}
+                      variant={isSelected ? 'outlined' : 'elevation'}
+                      elevation={isSelected ? 0 : 1}
+                      sx={{
+                        borderColor: isSelected ? 'primary.main' : undefined,
+                        px: 1.5,
+                        py: 1,
+                        cursor: 'pointer',
+                        transition: 'border-color 0.2s ease',
+                        '&:hover': { borderColor: 'primary.main', boxShadow: '0 0 0 1px rgba(37,115,255,0.24)' },
+                      }}
+                      onClick={() => {
+                        setSelectedVoiceId(voice.voiceId);
+                        if (voice.settings) {
+                          setVoiceSettings((prev) => ({ ...prev, ...voice.settings }));
+                        }
+                      }}
+                    >
+                      <Stack direction="row" alignItems="center" spacing={1.5}>
+                        <Radio
+                          checked={isSelected}
+                          value={voice.voiceId}
+                          onChange={() => setSelectedVoiceId(voice.voiceId)}
+                          inputProps={{ 'aria-label': voice.name }}
+                        />
+                        <Box sx={{ flexGrow: 1 }}>
+                          <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+                            {voice.name}
+                          </Typography>
+                          <Typography variant="caption" color="text.secondary">
+                            {voice.voiceId}
+                          </Typography>
+                        </Box>
+                        {voice.previewUrl && (
+                          <IconButton
+                            aria-label={`Preview ${voice.name}`}
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              handlePreview(voice);
+                            }}
+                            size="small"
+                          >
+                            {isPreviewing ? <StopIcon fontSize="small" /> : <PlayArrowIcon fontSize="small" />}
+                          </IconButton>
+                        )}
+                      </Stack>
+                    </Paper>
+                  );
+                })}
+                {!voicesQuery.isLoading && filteredVoices.length === 0 && (
+                  <Typography variant="body2" color="text.secondary">
+                    No voices match your search.
+                  </Typography>
+                )}
+                {voicesQuery.isLoading && (
+                  <Stack direction="row" spacing={1} alignItems="center" justifyContent="center" py={2}>
+                    <CircularProgress size={18} />
+                    <Typography variant="body2">Loading voices…</Typography>
+                  </Stack>
+                )}
+              </Stack>
+            </Stack>
+            <Divider flexItem orientation="vertical" sx={{ display: { xs: 'none', md: 'block' } }} />
+            <Stack spacing={2} flex={1}>
+              <Button
+                variant="text"
+                onClick={() => setAdvancedOpen((prev) => !prev)}
+                sx={{ alignSelf: 'flex-start', px: 0 }}
+              >
+                {showAdvancedHint}
+              </Button>
+              <Collapse in={advancedOpen} unmountOnExit>
+                <Stack spacing={2}>
+                  <Box>
+                    <Typography variant="caption" color="text.secondary">Stability ({voiceSettings.stability?.toFixed(2) ?? '—'})</Typography>
+                    <Slider
+                      value={voiceSettings.stability ?? DEFAULT_VOICE_SETTINGS.stability ?? 0}
+                      onChange={(_, value) =>
+                        setVoiceSettings((prev) => ({ ...prev, stability: Array.isArray(value) ? value[0] : value }))
+                      }
+                      step={0.05}
+                      min={0}
+                      max={1}
+                    />
+                  </Box>
+                  <Box>
+                    <Typography variant="caption" color="text.secondary">
+                      Similarity boost ({voiceSettings.similarity_boost?.toFixed(2) ?? '—'})
+                    </Typography>
+                    <Slider
+                      value={voiceSettings.similarity_boost ?? DEFAULT_VOICE_SETTINGS.similarity_boost ?? 0}
+                      onChange={(_, value) =>
+                        setVoiceSettings((prev) => ({ ...prev, similarity_boost: Array.isArray(value) ? value[0] : value }))
+                      }
+                      step={0.05}
+                      min={0}
+                      max={1}
+                    />
+                  </Box>
+                  <Box>
+                    <Typography variant="caption" color="text.secondary">Style ({voiceSettings.style?.toFixed(2) ?? '—'})</Typography>
+                    <Slider
+                      value={voiceSettings.style ?? DEFAULT_VOICE_SETTINGS.style ?? 0}
+                      onChange={(_, value) =>
+                        setVoiceSettings((prev) => ({ ...prev, style: Array.isArray(value) ? value[0] : value }))
+                      }
+                      step={0.05}
+                      min={0}
+                      max={1}
+                    />
+                  </Box>
+                  <Box>
+                    <Typography variant="caption" color="text.secondary">Speed ({voiceSettings.speed?.toFixed(2) ?? '—'})</Typography>
+                    <Slider
+                      value={voiceSettings.speed ?? DEFAULT_VOICE_SETTINGS.speed ?? 1}
+                      onChange={(_, value) =>
+                        setVoiceSettings((prev) => ({ ...prev, speed: Array.isArray(value) ? value[0] : value }))
+                      }
+                      step={0.05}
+                      min={0.5}
+                      max={1.5}
+                    />
+                  </Box>
+                  <Stack direction="row" spacing={1} alignItems="center">
+                    <Switch
+                      checked={voiceSettings.use_speaker_boost ?? DEFAULT_VOICE_SETTINGS.use_speaker_boost ?? false}
+                      onChange={(event) =>
+                        setVoiceSettings((prev) => ({ ...prev, use_speaker_boost: event.target.checked }))
+                      }
+                    />
+                    <Typography variant="body2">Use speaker boost</Typography>
+                  </Stack>
+                </Stack>
+              </Collapse>
+            </Stack>
+          </Stack>
+
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems={{ xs: 'stretch', sm: 'center' }}>
+            <Button
+              variant="contained"
+              onClick={handleGenerateAudio}
+              disabled={!canGenerate}
+              sx={{ minWidth: 200 }}
+            >
+              {isSubmitting || (job && !isTerminalStatus(job.status)) ? (
+                <Stack direction="row" spacing={1} alignItems="center" justifyContent="center">
+                  <CircularProgress size={18} sx={{ color: 'white' }} />
+                  <span>Generating…</span>
+                </Stack>
+              ) : (
+                'Generate audio'
+              )}
+            </Button>
+            {needsRegeneration && (
+              <Button variant="outlined" color="warning" onClick={handleReplaceAudio} startIcon={<ReplayIcon />}>
+                Regenerate with new transcript
+              </Button>
+            )}
+          </Stack>
+
+          {jobError && (
+            <Alert severity="error" ref={bannerRef} tabIndex={-1} sx={{ outline: 'none' }}>
+              <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} alignItems={{ xs: 'flex-start', sm: 'center' }}>
+                <Typography variant="body2">{jobError}</Typography>
+                <Button size="small" color="inherit" onClick={handleRetry} startIcon={<ReplayIcon fontSize="small" />}>
+                  Retry
+                </Button>
+              </Stack>
+            </Alert>
+          )}
+
+          {!jobError && job && !isTerminalStatus(job.status) && (
+            <Alert severity="info" ref={bannerRef} tabIndex={-1} icon={<CircularProgress size={16} />} sx={{ outline: 'none' }}>
+              <Typography variant="body2">Audio generation in progress… ({job.status})</Typography>
+            </Alert>
+          )}
+
+          {!job && !audioContent && (
+            <Alert severity="info" ref={bannerRef} tabIndex={-1} sx={{ outline: 'none' }}>
+              Start the audio job once your transcript looks good. You can regenerate as many times as you like.
+            </Alert>
+          )}
+
+          {audioContent && (
+            <Stack spacing={1.5}>
+              <Alert severity={needsRegeneration ? 'warning' : 'success'} ref={bannerRef} tabIndex={-1} sx={{ outline: 'none' }}>
+                {needsRegeneration
+                  ? 'The transcript changed after this audio was generated. Generate a fresh take to stay in sync.'
+                  : 'Audio ready! Preview below and replace it anytime.'}
+              </Alert>
+              <audio
+                controls
+                src={audioContent.audioUrl}
+                preload="none"
+                style={{ width: '100%' }}
+              >
+                Your browser does not support the audio element.
+              </audio>
+              <Stack direction="row" spacing={2} alignItems="center" justifyContent="space-between">
+                <Typography variant="body2" color="text.secondary">
+                  Duration: {audioContent.durationSec ? Math.round(audioContent.durationSec) : '—'} sec
+                </Typography>
+                <Button size="small" variant="text" color="primary" onClick={handleReplaceAudio} startIcon={<ReplayIcon fontSize="small" />}>
+                  Replace audio
+                </Button>
+              </Stack>
+            </Stack>
+          )}
+        </Stack>
+      </Paper>
+
+      {currentStatus === 'SUCCEEDED' && !audioContent && !jobError && (
+        <Typography variant="body2" color="error">
+          Audio job succeeded but preview is unavailable. Please try regenerating.
+        </Typography>
+      )}
+    </Stack>
+  );
+};
+
+export default ListeningAudioGenerationPanel;

--- a/src/pages/homework/TeacherHomeworkNewPage.tsx
+++ b/src/pages/homework/TeacherHomeworkNewPage.tsx
@@ -1,16 +1,47 @@
-import React, { useEffect, useState } from 'react';
-import { Box, Button, Container, Grid, MenuItem, Stack, TextField, Typography, Autocomplete, CircularProgress, Chip, Dialog, DialogTitle, DialogContent, DialogActions, FormControlLabel, Checkbox } from '@mui/material';
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Autocomplete,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Container,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  Grid,
+  MenuItem,
+  Paper,
+  Slider,
+  Stack,
+  TextField,
+  Typography,
+  Checkbox,
+  Divider,
+} from '@mui/material';
 import { CreateAssignmentDto, HomeworkTaskType, SourceKind } from '../../types/homework';
 import { useAuth } from '../../context/AuthContext';
 import { useCreateAssignment } from '../../hooks/useHomeworks';
 import { useAssignWords } from '../../hooks/useAssignments';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { toOffsetDateTime } from '../../utils/datetime';
-import { fetchStudents, fetchUserById } from '../../services/api';
-import { useQuery } from '@tanstack/react-query';
+import { fetchStudents, fetchUserById, generateListeningTranscript, updateListeningTranscript, validateListeningTranscript } from '../../services/api';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { vocabApi } from '../../services/vocabulary.api';
 import VocabularyList from '../../components/vocabulary/VocabularyList';
-import type { VocabularyWord } from '../../types';
+import type {
+  GenerateListeningTranscriptPayload,
+  ListeningGeneratedAudioContentRef,
+  ListeningTranscriptResponse,
+  ValidateListeningTranscriptPayload,
+  ValidateListeningTranscriptResponse,
+  VocabularyWord,
+} from '../../types';
+import { ENGLISH_LEVELS } from '../../types/ENGLISH_LEVELS';
+import ListeningAudioGenerationPanel from '../../components/listening/ListeningAudioGenerationPanel';
 
 const TeacherHomeworkNewPage: React.FC = () => {
   const { user } = useAuth();
@@ -42,7 +73,32 @@ const TeacherHomeworkNewPage: React.FC = () => {
   const [shuffle, setShuffle] = useState<boolean>(true);
   const [timeLimitMin, setTimeLimitMin] = useState<string>('');
 
+  // Listening transcript generation state
+  const [listeningDurationSecTarget, setListeningDurationSecTarget] = useState<number>(90);
+  const [listeningTheme, setListeningTheme] = useState('');
+  const [listeningLanguage, setListeningLanguage] = useState('en-US');
+  const [listeningCefr, setListeningCefr] = useState('B1');
+  const [listeningStyle, setListeningStyle] = useState('neutral');
+  const [listeningSeed, setListeningSeed] = useState('');
+  const [listeningMustIncludeAll, setListeningMustIncludeAll] = useState(true);
+  const [transcriptId, setTranscriptId] = useState<string | null>(null);
+  const [transcriptDraft, setTranscriptDraft] = useState('');
+  const [transcriptMetadata, setTranscriptMetadata] = useState<ListeningTranscriptResponse['metadata']>({
+    language: listeningLanguage,
+    theme: listeningTheme,
+    cefr: listeningCefr,
+    style: listeningStyle,
+  });
+  const [estimatedDurationSec, setEstimatedDurationSec] = useState<number | null>(null);
+  const [wordCoverage, setWordCoverage] = useState<Record<string, boolean>>({});
+  const [coverageMissing, setCoverageMissing] = useState<string[]>([]);
+  const [transcriptError, setTranscriptError] = useState<string | null>(null);
+  const [transcriptInfo, setTranscriptInfo] = useState<string | null>(null);
+  const [hasUnsavedTranscriptEdits, setHasUnsavedTranscriptEdits] = useState(false);
+  const [audioContentRef, setAudioContentRef] = useState<ListeningGeneratedAudioContentRef | null>(null);
+
   const isVocabList = taskType === 'VOCAB' && sourceKind === 'VOCAB_LIST';
+  const isListeningTask = taskType === 'LISTENING';
 
   // Load vocabulary words
   const { data: allWords = [] } = useQuery<VocabularyWord[]>({
@@ -64,6 +120,303 @@ const TeacherHomeworkNewPage: React.FC = () => {
     const map = new Map(allWords.map(w => [w.id, w] as const));
     return selectedWordIds.map(id => map.get(id)).filter(Boolean) as VocabularyWord[];
   }, [allWords, selectedWordIds]);
+
+  const listeningWordIds = useMemo(
+    () => selectedWordIds.filter((id) => id && id.trim().length > 0),
+    [selectedWordIds],
+  );
+
+  const listeningWordRequirementMet = listeningWordIds.length >= 3;
+
+  const cefrOptions = useMemo(() => Array.from(new Set(Object.values(ENGLISH_LEVELS).map(level => level.code))), []);
+  const languageOptions = useMemo(() => ['en-US', 'en-GB', 'en-AU', 'es-ES', 'fr-FR', 'de-DE'], []);
+  const styleOptions = useMemo(() => ['neutral', 'storytelling', 'documentary', 'conversational', 'inspirational'], []);
+  const taskTypeOptions: HomeworkTaskType[] = ['VIDEO', 'READING', 'GRAMMAR', 'VOCAB', 'LISTENING', 'LINK'];
+  const durationMarks = useMemo(() => (
+    [
+      { value: 45, label: '0:45' },
+      { value: 60, label: '1:00' },
+      { value: 90, label: '1:30' },
+      { value: 120, label: '2:00' },
+    ]
+  ), []);
+  const sourceKindOptions: SourceKind[] = ['MATERIAL', 'LESSON_CONTENT', 'EXTERNAL_URL', 'VOCAB_LIST', 'GENERATED_AUDIO'];
+
+  const formatDurationLabel = (value: number) => {
+    const mins = Math.floor(value / 60);
+    const secs = Math.max(0, value % 60);
+    return `${mins}:${secs.toString().padStart(2, '0')}`;
+  };
+
+  const isVocabSelectionInvalid = selectedWordIds.length < 5 || selectedWordIds.length > 100;
+  const createDisabled =
+    create.isPending ||
+    !studentId ||
+    (isVocabList && isVocabSelectionInvalid) ||
+    (isListeningTask && (!transcriptId || hasUnsavedTranscriptEdits || !listeningWordRequirementMet || !audioContentRef));
+
+  const generateTranscriptMutation = useMutation<
+    ListeningTranscriptResponse,
+    Error,
+    GenerateListeningTranscriptPayload
+  >({
+    mutationFn: async (payload) => {
+      if (!user?.id) {
+        throw new Error('You need to be signed in to generate transcripts.');
+      }
+      return generateListeningTranscript(user.id, payload);
+    },
+  });
+  const updateTranscriptMutation = useMutation<ListeningTranscriptResponse, Error, { transcriptId: string; transcript: string }>(
+    {
+      mutationFn: async ({ transcriptId, transcript }) => {
+        if (!user?.id) {
+          throw new Error('You need to be signed in to save transcripts.');
+        }
+        return updateListeningTranscript(user.id, transcriptId, { transcript });
+      },
+    }
+  );
+  const validateTranscriptMutation = useMutation<ValidateListeningTranscriptResponse, Error, ValidateListeningTranscriptPayload>({
+    mutationFn: (payload) => validateListeningTranscript(payload),
+  });
+
+  const coverageEntries = useMemo(() => {
+    if (selectedWordChips.length === 0) return [] as Array<{ word: string; covered: boolean }>;
+    return selectedWordChips.map((word) => {
+      const normalized = word.text.trim();
+      const lower = normalized.toLowerCase();
+      const covered = Boolean(
+        wordCoverage[normalized] ?? wordCoverage[lower] ?? wordCoverage[word.text] ?? false,
+      );
+      return { word: normalized, covered };
+    });
+  }, [selectedWordChips, wordCoverage]);
+
+  const coverageSatisfied = useMemo(
+    () => coverageEntries.length > 0 && coverageEntries.every((entry) => entry.covered),
+    [coverageEntries],
+  );
+
+  const formattedEstimatedDuration = useMemo(() => {
+    if (estimatedDurationSec == null) return null;
+    const mins = Math.floor(estimatedDurationSec / 60);
+    const secs = Math.max(0, estimatedDurationSec % 60);
+    return `${mins}:${secs.toString().padStart(2, '0')}`;
+  }, [estimatedDurationSec]);
+
+  const highlightedTranscript = useMemo(() => {
+    if (!transcriptDraft) {
+      return [] as React.ReactNode[];
+    }
+
+    const escapeRegExp = (value: string) => value.replace(/([-\\^$*+?.()|[\]{}])/g, '\\$1');
+    const uniqueWords = Array.from(
+      new Set(
+        selectedWordChips
+          .map((word) => word.text.trim())
+          .filter((word) => word.length > 0),
+      ),
+    );
+
+    if (uniqueWords.length === 0) {
+      return [transcriptDraft];
+    }
+
+    const pattern = new RegExp(
+      uniqueWords
+        .sort((a, b) => b.length - a.length)
+        .map((word) => escapeRegExp(word))
+        .join('|'),
+      'gi',
+    );
+
+    const nodes: React.ReactNode[] = [];
+    let lastIndex = 0;
+    let match: RegExpExecArray | null;
+
+    while ((match = pattern.exec(transcriptDraft)) !== null) {
+      if (match.index > lastIndex) {
+        nodes.push(transcriptDraft.slice(lastIndex, match.index));
+      }
+
+      const matchedText = match[0];
+      nodes.push(
+        <Box
+          key={`hit-${match.index}-${matchedText}-${nodes.length}`}
+          component="strong"
+          sx={{ fontWeight: 700, color: '#1d4ed8' }}
+        >
+          {matchedText}
+        </Box>,
+      );
+
+      lastIndex = match.index + matchedText.length;
+    }
+
+    if (lastIndex < transcriptDraft.length) {
+      nodes.push(transcriptDraft.slice(lastIndex));
+    }
+
+    if (nodes.length === 0) {
+      return [transcriptDraft];
+    }
+
+    return nodes;
+  }, [selectedWordChips, transcriptDraft]);
+
+  useEffect(() => {
+    if (isListeningTask) {
+      setSourceKind('GENERATED_AUDIO');
+    } else if (sourceKind === 'GENERATED_AUDIO') {
+      setSourceKind('EXTERNAL_URL');
+    }
+  }, [isListeningTask, sourceKind]);
+
+  useEffect(() => {
+    if (!isListeningTask) {
+      setTranscriptId(null);
+      setTranscriptDraft('');
+      setWordCoverage({});
+      setCoverageMissing([]);
+      setEstimatedDurationSec(null);
+      setTranscriptError(null);
+      setTranscriptInfo(null);
+      setHasUnsavedTranscriptEdits(false);
+      setAudioContentRef(null);
+    }
+  }, [isListeningTask]);
+
+  useEffect(() => {
+    if (!isListeningTask || transcriptId) return;
+    setTranscriptMetadata({
+      language: listeningLanguage,
+      theme: listeningTheme || undefined,
+      cefr: listeningCefr,
+      style: listeningStyle,
+    });
+  }, [isListeningTask, transcriptId, listeningLanguage, listeningTheme, listeningCefr, listeningStyle]);
+
+  const buildCoverageMissing = (coverage: Record<string, boolean> | undefined) =>
+    Object.entries(coverage ?? {})
+      .filter(([, covered]) => !covered)
+      .map(([word]) => word);
+
+  const handleGenerateTranscript = async () => {
+    setTranscriptError(null);
+    setTranscriptInfo(null);
+
+    if (!isListeningTask) return;
+
+    if (!listeningWordRequirementMet) {
+      setTranscriptError('Select at least 3 focus words to guide the story.');
+      return;
+    }
+
+    const payload: GenerateListeningTranscriptPayload = {
+      wordIds: listeningWordIds,
+      durationSecTarget: listeningDurationSecTarget,
+      theme: listeningTheme || undefined,
+      cefr: listeningCefr || undefined,
+      language: listeningLanguage || undefined,
+      style: listeningStyle || undefined,
+      constraints: listeningMustIncludeAll ? { mustIncludeAllWords: true } : undefined,
+    };
+
+    if (listeningSeed.trim()) {
+      const parsedSeed = Number(listeningSeed.trim());
+      if (Number.isNaN(parsedSeed)) {
+        setTranscriptError('Seed must be a number.');
+        return;
+      }
+      payload.seed = parsedSeed;
+    }
+
+    try {
+      const result = await generateTranscriptMutation.mutateAsync(payload);
+      setTranscriptId(result.transcriptId);
+      setTranscriptDraft(result.transcript ?? '');
+      setWordCoverage(result.wordCoverage ?? {});
+      setCoverageMissing(buildCoverageMissing(result.wordCoverage));
+      setEstimatedDurationSec(result.estimatedDurationSec ?? null);
+      setTranscriptMetadata(
+        result.metadata ?? {
+          language: listeningLanguage,
+          theme: listeningTheme || undefined,
+          cefr: listeningCefr,
+          style: listeningStyle,
+        },
+      );
+      setHasUnsavedTranscriptEdits(false);
+      setTranscriptInfo('Transcript generated. Tweak the draft if needed, then save.');
+      setAudioContentRef(null);
+    } catch (error) {
+      console.error('Failed to generate transcript', error);
+      setTranscriptError(
+        error instanceof Error ? error.message : 'Failed to generate transcript. Please try again.',
+      );
+    }
+  };
+
+  const handleSaveTranscript = async () => {
+    if (!transcriptId) return;
+
+    setTranscriptError(null);
+    setTranscriptInfo(null);
+
+    try {
+      const result = await updateTranscriptMutation.mutateAsync({
+        transcriptId,
+        transcript: transcriptDraft.trim(),
+      });
+      setTranscriptDraft(result.transcript ?? transcriptDraft);
+      setWordCoverage(result.wordCoverage ?? {});
+      setCoverageMissing(buildCoverageMissing(result.wordCoverage));
+      setEstimatedDurationSec(result.estimatedDurationSec ?? estimatedDurationSec);
+      setTranscriptMetadata(result.metadata ?? transcriptMetadata);
+      setHasUnsavedTranscriptEdits(false);
+      setTranscriptInfo('Transcript saved.');
+    } catch (error) {
+      console.error('Failed to save transcript', error);
+      setTranscriptError(
+        error instanceof Error ? error.message : 'Could not save transcript. Please try again.',
+      );
+    }
+  };
+
+  const handleValidateTranscript = async () => {
+    setTranscriptError(null);
+    setTranscriptInfo(null);
+
+    if (!transcriptDraft.trim()) {
+      setTranscriptError('Transcript text cannot be empty.');
+      return;
+    }
+
+    if (!listeningWordRequirementMet) {
+      setTranscriptError('Make sure you selected enough vocabulary words before validating.');
+      return;
+    }
+
+    try {
+      const result = await validateTranscriptMutation.mutateAsync({
+        transcript: transcriptDraft,
+        wordIds: listeningWordIds,
+      });
+      setWordCoverage(result.wordCoverage ?? {});
+      setCoverageMissing(buildCoverageMissing(result.wordCoverage));
+      setTranscriptInfo(
+        result.missing.length === 0
+          ? 'Every target word is present. Ready for audio!'
+          : 'Some words are still missing. Consider tweaking the text.',
+      );
+    } catch (error) {
+      console.error('Failed to validate transcript', error);
+      setTranscriptError(
+        error instanceof Error ? error.message : 'Validation failed. Try again in a moment.',
+      );
+    }
+  };
 
   // fetch student options debounced by query
   useEffect(() => {
@@ -110,6 +463,67 @@ const TeacherHomeworkNewPage: React.FC = () => {
         sourceKind: 'VOCAB_LIST',
         instructions: undefined,
         contentRef: { wordIds: selectedWordIds, settings },
+        vocabWordIds: selectedWordIds,
+      });
+    } else if (isListeningTask) {
+      setTranscriptError(null);
+      setTranscriptInfo(null);
+      if (!transcriptId) {
+        setTranscriptError('Generate the transcript before creating the homework.');
+        return;
+      }
+
+      if (hasUnsavedTranscriptEdits) {
+        setTranscriptError('Save your transcript edits before continuing.');
+        return;
+      }
+
+      if (!listeningWordRequirementMet) {
+        setTranscriptError('Please verify the selected vocabulary before creating the task.');
+        return;
+      }
+
+      if (!audioContentRef) {
+        setTranscriptError('Generate audio for the transcript before saving this task.');
+        return;
+      }
+
+      const generatorParams = {
+        wordIds: listeningWordIds,
+        durationSecTarget: listeningDurationSecTarget,
+        theme: listeningTheme || undefined,
+        cefr: listeningCefr || undefined,
+        language: listeningLanguage || undefined,
+        style: listeningStyle || undefined,
+        constraints: listeningMustIncludeAll ? { mustIncludeAllWords: true } : undefined,
+        seed: listeningSeed.trim() ? Number(listeningSeed.trim()) : undefined,
+      };
+
+      const durationSec = audioContentRef?.durationSec ?? estimatedDurationSec ?? listeningDurationSecTarget;
+      const transcriptText = audioContentRef?.transcript ?? transcriptDraft.trim();
+
+      const listeningContentRef = {
+        generatorRequestId: audioContentRef.generatorRequestId,
+        audioMaterialId: audioContentRef.audioMaterialId,
+        audioUrl: audioContentRef.audioUrl,
+        transcriptId,
+        transcript: transcriptText,
+        durationSec,
+        wordIds: listeningWordIds,
+        theme: audioContentRef.theme ?? (listeningTheme || undefined),
+        cefr: audioContentRef.cefr ?? (listeningCefr || undefined),
+        metadata: transcriptMetadata,
+        wordCoverage,
+        generatorParams,
+        voiceId: audioContentRef.voiceId,
+      };
+
+      tasks.push({
+        title: taskTitle,
+        type: 'LISTENING',
+        sourceKind: 'GENERATED_AUDIO',
+        instructions: undefined,
+        contentRef: listeningContentRef,
         vocabWordIds: selectedWordIds,
       });
     } else {
@@ -202,20 +616,36 @@ const TeacherHomeworkNewPage: React.FC = () => {
             <Typography variant="subtitle1">Task</Typography>
             <TextField label="Task title" value={taskTitle} onChange={e => setTaskTitle(e.target.value)} fullWidth />
             <TextField select label="Task type" value={taskType} onChange={e => setTaskType(e.target.value as HomeworkTaskType)}>
-              {['VIDEO','READING','GRAMMAR','VOCAB','LINK'].map(t => (<MenuItem key={t} value={t}>{t}</MenuItem>))}
+              {taskTypeOptions.map(t => (<MenuItem key={t} value={t}>{t}</MenuItem>))}
             </TextField>
-            <TextField select label="Source kind" value={sourceKind} onChange={e => setSourceKind(e.target.value as SourceKind)}>
-              {['MATERIAL','LESSON_CONTENT','EXTERNAL_URL','VOCAB_LIST'].map(s => (<MenuItem key={s} value={s}>{s}</MenuItem>))}
-            </TextField>
-            {sourceKind === 'EXTERNAL_URL' && (
+            {!isListeningTask ? (
+              <TextField select label="Source kind" value={sourceKind} onChange={e => setSourceKind(e.target.value as SourceKind)}>
+                {sourceKindOptions.filter(s => s !== 'GENERATED_AUDIO').map(s => (<MenuItem key={s} value={s}>{s}</MenuItem>))}
+              </TextField>
+            ) : (
+              <TextField label="Source kind" value="GENERATED_AUDIO" InputProps={{ readOnly: true }} disabled />
+            )}
+            {sourceKind === 'EXTERNAL_URL' && !isListeningTask && (
               <TextField label="Source URL" value={sourceUrl} onChange={e => setSourceUrl(e.target.value)} fullWidth />
             )}
-            {isVocabList && (
+            {(isVocabList || isListeningTask) && (
               <Stack spacing={1} sx={{ mt: 1 }}>
                 <Stack direction="row" spacing={1} alignItems="center">
-                  <Button variant="outlined" onClick={() => setPickerOpen(true)}>Select words</Button>
-                  <Chip size="small" color={selectedWordIds.length >= 5 ? 'success' : 'warning'} label={`${selectedWordIds.length} selected`} />
-                  <Typography variant="caption" color="text.secondary">Choose 5–100 words</Typography>
+                  <Button variant="outlined" onClick={() => setPickerOpen(true)}>
+                    {isListeningTask ? 'Pick focus words' : 'Select words'}
+                  </Button>
+                  <Chip
+                    size="small"
+                    color={
+                      isVocabList
+                        ? (!isVocabSelectionInvalid ? 'success' : 'warning')
+                        : (listeningWordRequirementMet ? 'success' : 'warning')
+                    }
+                    label={`${selectedWordIds.length} selected`}
+                  />
+                  <Typography variant="caption" color="text.secondary">
+                    {isVocabList ? 'Choose 5–100 words' : 'Pick 3+ words to anchor the transcript'}
+                  </Typography>
                 </Stack>
                 {selectedWordChips.length > 0 && (
                   <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
@@ -227,28 +657,237 @@ const TeacherHomeworkNewPage: React.FC = () => {
                     )}
                   </Stack>
                 )}
-                {(selectedWordIds.length < 5 || selectedWordIds.length > 100) && (
+                {isVocabList && isVocabSelectionInvalid && (
                   <Typography variant="caption" color="error">Please select between 5 and 100 words.</Typography>
                 )}
-                <TextField type="number" label="Mastery streak" value={masteryStreak}
-                           onChange={e => setMasteryStreak(Math.max(1, Math.min(10, Number(e.target.value) || 0)))}
-                           InputLabelProps={{ shrink: true }} inputProps={{ min: 1, max: 10 }} />
-                <FormControlLabel control={<Checkbox checked={shuffle} onChange={(e)=> setShuffle(e.target.checked)} />} label="Shuffle words" />
-                <TextField type="number" label="Time limit (minutes)" value={timeLimitMin}
-                           onChange={e => setTimeLimitMin(e.target.value)} InputLabelProps={{ shrink: true }}
-                           helperText="Optional: leave empty for no timer" />
+                {isListeningTask && !listeningWordRequirementMet && (
+                  <Typography variant="caption" color="error">
+                    Please select at least 3 words to proceed.
+                  </Typography>
+                )}
+                {isVocabList && (
+                  <>
+                    <TextField type="number" label="Mastery streak" value={masteryStreak}
+                               onChange={e => setMasteryStreak(Math.max(1, Math.min(10, Number(e.target.value) || 0)))}
+                               InputLabelProps={{ shrink: true }} inputProps={{ min: 1, max: 10 }} />
+                    <FormControlLabel control={<Checkbox checked={shuffle} onChange={(e)=> setShuffle(e.target.checked)} />} label="Shuffle words" />
+                    <TextField type="number" label="Time limit (minutes)" value={timeLimitMin}
+                               onChange={e => setTimeLimitMin(e.target.value)} InputLabelProps={{ shrink: true }}
+                               helperText="Optional: leave empty for no timer" />
+                  </>
+                )}
+                {isListeningTask && (
+                  <Typography variant="caption" color="text.secondary">
+                    Vocabulary mastery settings are ignored for listening tasks.
+                  </Typography>
+                )}
               </Stack>
+            )}
+            {isListeningTask && (
+              <Paper elevation={0} sx={{ p: 2.5, borderRadius: 3, border: '1px solid rgba(37,115,255,0.12)', background: '#ffffff' }}>
+                <Stack spacing={2.5}>
+                  <Box>
+                    <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>AI transcript lab</Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      Shape the scenario, then let the AI craft a script that weaves in every chosen word.
+                    </Typography>
+                  </Box>
+
+                  {(transcriptError || transcriptInfo) && (
+                    <Stack spacing={1}>
+                      {transcriptError && <Alert severity="error">{transcriptError}</Alert>}
+                      {transcriptInfo && !transcriptError && <Alert severity="success">{transcriptInfo}</Alert>}
+                    </Stack>
+                  )}
+
+                  <Stack spacing={2}>
+                    <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems="stretch">
+                      <Box flex={1}>
+                        <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1 }}>Target duration</Typography>
+                        <Slider
+                          value={listeningDurationSecTarget}
+                          onChange={(_, value) => setListeningDurationSecTarget(Array.isArray(value) ? value[0] : value)}
+                          min={45}
+                          max={150}
+                          step={15}
+                          marks={durationMarks}
+                          valueLabelDisplay="on"
+                          valueLabelFormat={(value) => formatDurationLabel(value as number)}
+                          sx={{ px: 1 }}
+                        />
+                      </Box>
+                      <TextField
+                        fullWidth
+                        label="Theme"
+                        placeholder="Wildlife conservation"
+                        value={listeningTheme}
+                        onChange={(e) => setListeningTheme(e.target.value)}
+                      />
+                    </Stack>
+
+                    <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+                      <TextField select label="Language" value={listeningLanguage} onChange={(e) => setListeningLanguage(e.target.value)} fullWidth>
+                        {languageOptions.map(lang => <MenuItem key={lang} value={lang}>{lang}</MenuItem>)}
+                      </TextField>
+                      <TextField select label="CEFR" value={listeningCefr} onChange={(e) => setListeningCefr(e.target.value)} fullWidth>
+                        {cefrOptions.map(level => <MenuItem key={level} value={level}>{level}</MenuItem>)}
+                      </TextField>
+                    </Stack>
+
+                    <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+                      <TextField select label="Narration style" value={listeningStyle} onChange={(e) => setListeningStyle(e.target.value)} fullWidth>
+                        {styleOptions.map(style => <MenuItem key={style} value={style}>{style}</MenuItem>)}
+                      </TextField>
+                      <TextField
+                        label="Seed (optional)"
+                        value={listeningSeed}
+                        onChange={(e) => {
+                          const val = e.target.value;
+                          if (/^-?\d*$/.test(val)) {
+                            setListeningSeed(val);
+                          }
+                        }}
+                        placeholder="42"
+                        inputProps={{ inputMode: 'numeric', pattern: '-?[0-9]*' }}
+                        fullWidth
+                      />
+                    </Stack>
+
+                    <FormControlLabel
+                      control={<Checkbox checked={listeningMustIncludeAll} onChange={(e) => setListeningMustIncludeAll(e.target.checked)} />}
+                      label="Force every selected word to appear"
+                    />
+                  </Stack>
+
+                  <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems={{ xs: 'stretch', sm: 'center' }}>
+                    <Button
+                      variant="contained"
+                      onClick={handleGenerateTranscript}
+                      disabled={generateTranscriptMutation.isPending}
+                      sx={{ minWidth: 200 }}
+                    >
+                      {generateTranscriptMutation.isPending ? <CircularProgress size={18} sx={{ color: 'white' }} /> : 'Generate transcript'}
+                    </Button>
+                    <Button
+                      variant="outlined"
+                      onClick={handleValidateTranscript}
+                      disabled={validateTranscriptMutation.isPending || !transcriptDraft}
+                    >
+                      {validateTranscriptMutation.isPending ? <CircularProgress size={18} /> : 'Validate coverage'}
+                    </Button>
+                    <Button
+                      variant="outlined"
+                      color="success"
+                      onClick={handleSaveTranscript}
+                      disabled={!transcriptId || !hasUnsavedTranscriptEdits || updateTranscriptMutation.isPending}
+                    >
+                      {updateTranscriptMutation.isPending ? <CircularProgress size={18} /> : 'Save edits'}
+                    </Button>
+                  </Stack>
+
+                  <Divider sx={{ my: 1 }} />
+
+                  <Stack spacing={1.5}>
+                    <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>Transcript draft</Typography>
+                    <TextField
+                      value={transcriptDraft}
+                      onChange={(e) => {
+                        setTranscriptDraft(e.target.value);
+                        setHasUnsavedTranscriptEdits(true);
+                      }}
+                      multiline
+                      minRows={6}
+                      placeholder="The rainforest is a vibrant, sustainable habitat..."
+                    />
+                    {transcriptDraft && (
+                      <Box
+                        sx={{
+                          borderRadius: 2,
+                          border: '1px solid rgba(37,115,255,0.16)',
+                          bgcolor: 'rgba(37,115,255,0.04)',
+                          px: 2,
+                          py: 1.5,
+                        }}
+                      >
+                        <Typography variant="overline" sx={{ letterSpacing: 1, color: '#1d4ed8' }}>
+                          Preview with highlighted words
+                        </Typography>
+                        <Typography
+                          variant="body1"
+                          sx={{ whiteSpace: 'pre-wrap', lineHeight: 1.6, color: '#1a1c1f' }}
+                        >
+                          {highlightedTranscript}
+                        </Typography>
+                      </Box>
+                    )}
+                    <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems={{ xs: 'flex-start', sm: 'center' }}>
+                      {formattedEstimatedDuration && (
+                        <Typography variant="body2" color="text.secondary">
+                          Estimated runtime: {formattedEstimatedDuration}
+                        </Typography>
+                      )}
+                      {transcriptMetadata?.language && (
+                        <Typography variant="body2" color="text.secondary">
+                          {transcriptMetadata.language} • {transcriptMetadata.cefr ?? listeningCefr} • {transcriptMetadata.style ?? listeningStyle}
+                        </Typography>
+                      )}
+                    </Stack>
+                    {coverageEntries.length > 0 && (
+                      <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
+                        {coverageEntries.map(({ word, covered }) => (
+                          <Chip
+                            key={word}
+                            label={word}
+                            size="small"
+                            color={covered ? 'success' : 'warning'}
+                            variant={covered ? 'filled' : 'outlined'}
+                          />
+                        ))}
+                      </Stack>
+                    )}
+                    {coverageMissing.length > 0 && (
+                      <Typography variant="caption" color="error">
+                        Missing words: {coverageMissing.join(', ')}
+                      </Typography>
+                    )}
+                    {hasUnsavedTranscriptEdits && (
+                      <Typography variant="caption" color="warning.main">
+                        You have unsaved edits. Save before assigning.
+                      </Typography>
+                    )}
+
+                    <ListeningAudioGenerationPanel
+                      transcriptId={transcriptId}
+                      transcriptText={transcriptDraft}
+                      metadata={transcriptMetadata}
+                      wordIds={listeningWordIds}
+                      coverageSatisfied={coverageSatisfied}
+                      disabled={!transcriptId}
+                      languageCode={listeningLanguage}
+                      theme={listeningTheme || undefined}
+                      cefr={listeningCefr || undefined}
+                      hasUnsavedTranscriptEdits={hasUnsavedTranscriptEdits}
+                      onAudioContentChange={(content) => setAudioContentRef(content)}
+                      onDurationUpdate={(duration) => {
+                        if (duration != null) {
+                          setEstimatedDurationSec(duration);
+                        }
+                      }}
+                    />
+                  </Stack>
+                </Stack>
+              </Paper>
             )}
           </Stack>
         </Grid>
       </Grid>
 
       <Box mt={3}>
-        <Button variant="contained" onClick={onSubmit} disabled={create.isPending || !studentId || (isVocabList && (selectedWordIds.length < 5 || selectedWordIds.length > 100))}>Create</Button>
+        <Button variant="contained" onClick={onSubmit} disabled={createDisabled}>Create</Button>
       </Box>
 
       <Dialog open={pickerOpen} onClose={() => setPickerOpen(false)} fullWidth maxWidth="md">
-        <DialogTitle>Select vocabulary words</DialogTitle>
+        <DialogTitle>{isListeningTask ? 'Select listening words' : 'Select vocabulary words'}</DialogTitle>
         <DialogContent>
           <Stack spacing={2} sx={{ mt: 1 }}>
             <TextField label="Search" value={wordSearch} onChange={e => setWordSearch(e.target.value)} fullWidth />

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -2,7 +2,19 @@ import axios from 'axios';
 import {Student} from "../pages/MyStudentsPage";
 import { NotificationMessage} from "../context/NotificationsSocketContext";
 import { ApiError } from '../context/ApiErrorContext';
-import {GenerateExerciseRequest, GenerateExerciseResponse} from "../types";
+import {
+    GenerateExerciseRequest,
+    GenerateExerciseResponse,
+    GenerateListeningTranscriptPayload,
+    ListeningTranscriptResponse,
+    ListeningAudioJobStartResponse,
+    ListeningAudioJobStatusResponse,
+    ListeningVoice,
+    StartListeningAudioJobPayload,
+    ValidateListeningTranscriptPayload,
+    ValidateListeningTranscriptResponse,
+    UpdateListeningTranscriptPayload,
+} from "../types";
 import { LESSON_CONTENTS_BASE } from '../constants/api';
 import type { PageModel, BlockContentPayload } from '../types/lessonContent';
 
@@ -615,6 +627,84 @@ export interface MicDiagPayload {
 export const postMicDiag = async (payload: MicDiagPayload) => {
   const res = await api.post(`/users-service/api/diag/mic-log`, payload);
   return res.data;
+};
+
+export const generateListeningTranscript = async (
+  teacherId: string,
+  payload: GenerateListeningTranscriptPayload,
+): Promise<ListeningTranscriptResponse> => {
+  const response = await api.post<ListeningTranscriptResponse>(
+    `/lessons-service/api/listening/transcripts/generate`,
+    payload,
+    { params: { teacherId } },
+  );
+  return response.data;
+};
+
+export const updateListeningTranscript = async (
+  teacherId: string,
+  transcriptId: string,
+  payload: UpdateListeningTranscriptPayload,
+): Promise<ListeningTranscriptResponse> => {
+  const response = await api.put<ListeningTranscriptResponse>(
+    `/lessons-service/api/listening/transcripts/${transcriptId}`,
+    payload,
+    { params: { teacherId } },
+  );
+  return response.data;
+};
+
+export const getListeningTranscript = async (
+  teacherId: string,
+  transcriptId: string,
+): Promise<ListeningTranscriptResponse> => {
+  const response = await api.get<ListeningTranscriptResponse>(
+    `/lessons-service/api/listening/transcripts/${transcriptId}`,
+    { params: { teacherId } },
+  );
+  return response.data;
+};
+
+export const validateListeningTranscript = async (
+  payload: ValidateListeningTranscriptPayload,
+): Promise<ValidateListeningTranscriptResponse> => {
+  const response = await api.post<ValidateListeningTranscriptResponse>(
+    `/lessons-service/api/listening/transcripts/validate`,
+    payload,
+  );
+  return response.data;
+};
+
+export const listListeningVoices = async (): Promise<ListeningVoice[]> => {
+  const response = await api.get<ListeningVoice[]>(`/api/listening/voices`);
+  return response.data;
+};
+
+export const startListeningAudioGeneration = async (
+  payload: StartListeningAudioJobPayload,
+  token: string,
+  idempotencyKey: string,
+): Promise<ListeningAudioJobStartResponse> => {
+  const response = await api.post<ListeningAudioJobStartResponse>(
+    `/api/listening/audio:generate`,
+    payload,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Idempotency-Key': idempotencyKey,
+      },
+    },
+  );
+  return response.data;
+};
+
+export const getListeningAudioJobStatus = async (
+  jobId: string,
+): Promise<ListeningAudioJobStatusResponse> => {
+  const response = await api.get<ListeningAudioJobStatusResponse>(
+    `/api/listening/audio/jobs/${jobId}`,
+  );
+  return response.data;
 };
 
 export default api;

--- a/src/types/homework.ts
+++ b/src/types/homework.ts
@@ -1,8 +1,13 @@
 // Homework domain types matching backend
 
-export type HomeworkTaskType = 'VIDEO' | 'READING' | 'GRAMMAR' | 'VOCAB' | 'LINK';
+export type HomeworkTaskType = 'VIDEO' | 'READING' | 'GRAMMAR' | 'VOCAB' | 'LINK' | 'LISTENING';
 export type HomeworkTaskStatus = 'NOT_STARTED' | 'IN_PROGRESS' | 'COMPLETED';
-export type SourceKind = 'MATERIAL' | 'LESSON_CONTENT' | 'EXTERNAL_URL' | 'VOCAB_LIST';
+export type SourceKind =
+  | 'MATERIAL'
+  | 'LESSON_CONTENT'
+  | 'EXTERNAL_URL'
+  | 'VOCAB_LIST'
+  | 'GENERATED_AUDIO';
 
 export interface TaskDto {
   id: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -51,3 +51,5 @@ export interface GenerateExerciseResponse {
     tokensUsed: number;
   };
 }
+
+export * from './listeningTranscript';

--- a/src/types/listeningTranscript.ts
+++ b/src/types/listeningTranscript.ts
@@ -1,0 +1,108 @@
+export interface ListeningTranscriptMetadata {
+  language?: string;
+  theme?: string;
+  cefr?: string;
+  style?: string;
+  [key: string]: unknown;
+}
+
+export interface ListeningVoiceSettings {
+  stability?: number;
+  similarity_boost?: number;
+  style?: number;
+  speed?: number;
+  use_speaker_boost?: boolean;
+  [key: string]: unknown;
+}
+
+export interface ListeningVoice {
+  voiceId: string;
+  name: string;
+  previewUrl?: string;
+  settings?: ListeningVoiceSettings;
+}
+
+export type ListeningAudioJobStatus =
+  | 'PENDING'
+  | 'RUNNING'
+  | 'SUCCEEDED'
+  | 'FAILED'
+  | 'CANCELLED'
+  | 'EXPIRED';
+
+export interface StartListeningAudioJobPayload {
+  transcriptId: string;
+  transcriptOverride?: string;
+  voiceId: string;
+  ttsModel: string;
+  languageCode: string;
+  voiceSettings: ListeningVoiceSettings;
+  outputFormat: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ListeningAudioJobStartResponse {
+  jobId: string;
+  status: ListeningAudioJobStatus;
+}
+
+export interface ListeningAudioJobStatusResponse {
+  jobId: string;
+  status: ListeningAudioJobStatus;
+  audioMaterialId?: string;
+  audioUrl?: string;
+  durationSec?: number;
+  transcript?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  message?: string;
+  error?: string;
+  [key: string]: unknown;
+}
+
+export interface ListeningGeneratedAudioContentRef {
+  sourceKind: 'GENERATED_AUDIO';
+  generatorRequestId: string;
+  audioMaterialId: string;
+  audioUrl: string;
+  transcript: string;
+  durationSec: number;
+  wordIds: string[];
+  theme?: string;
+  cefr?: string;
+  metadata?: ListeningTranscriptMetadata;
+  voiceId?: string;
+}
+
+export interface ListeningTranscriptResponse {
+  transcriptId: string;
+  transcript: string;
+  wordCoverage: Record<string, boolean>;
+  estimatedDurationSec?: number;
+  metadata?: ListeningTranscriptMetadata;
+}
+
+export interface GenerateListeningTranscriptPayload {
+  wordIds: string[];
+  durationSecTarget: number;
+  theme?: string;
+  cefr?: string;
+  language?: string;
+  style?: string;
+  seed?: number;
+  constraints?: Record<string, unknown>;
+}
+
+export interface UpdateListeningTranscriptPayload {
+  transcript: string;
+}
+
+export interface ValidateListeningTranscriptPayload {
+  transcript: string;
+  wordIds: string[];
+}
+
+export interface ValidateListeningTranscriptResponse {
+  wordCoverage: Record<string, boolean>;
+  missing: string[];
+}


### PR DESCRIPTION
## Summary
- add a dedicated ListeningAudioGenerationPanel that drives voice selection, async audio jobs, and previews
- wire the listening composer flows to persist generated audio metadata with tasks and require fresh audio before saving
- extend the student task frame to stream generated listening audio with progress tracking and transcript reveal gating

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d79d0cf4b8832cbae524cb66999346