### PR TITLE
Enable workspace materials in Daily call layout

### DIFF
--- a/src/components/lessonDetail/SyncedVideoPlayer.tsx
+++ b/src/components/lessonDetail/SyncedVideoPlayer.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import { Box } from '@mui/material';
 import ReactPlayer from 'react-player';
-import { Chat } from '@livekit/components-react';
 import { UseSyncedVideoResult } from '../../hooks/useSyncedVideo';
 import {StyledChat} from "./StyledChat";
 
 interface SyncedVideoPlayerProps {
   useSyncedVideo: UseSyncedVideoResult;
+  showChat?: boolean;
 }
 
-const SyncedVideoPlayer: React.FC<SyncedVideoPlayerProps> = ({ useSyncedVideo }) => {
+const SyncedVideoPlayer: React.FC<SyncedVideoPlayerProps> = ({ useSyncedVideo, showChat = true }) => {
   const { state, playerRef, play, pause, seek } = useSyncedVideo;
 
   // If the video is not open, don't render anything
@@ -21,6 +21,8 @@ const SyncedVideoPlayer: React.FC<SyncedVideoPlayerProps> = ({ useSyncedVideo })
     // broadcast seek when user drags the scrubber
     seek(seconds);
   };
+
+  const playerHeight = showChat ? '60%' : '100%';
 
   return (
     <Box
@@ -39,7 +41,7 @@ const SyncedVideoPlayer: React.FC<SyncedVideoPlayerProps> = ({ useSyncedVideo })
         playing={state.isPlaying}
         controls
         width="100%"
-        height="60%"   /* 60 % video, 40 % chat – tweak if needed */
+        height={playerHeight}   /* 60 % video, 40 % chat – tweak if needed */
         onPlay={play}
         onPause={pause}
         onSeek={handleSeek}
@@ -54,9 +56,11 @@ const SyncedVideoPlayer: React.FC<SyncedVideoPlayerProps> = ({ useSyncedVideo })
       />
 
       {/* --- chat --- */}
-      <Box sx={{ flexGrow: 1, minHeight: 0, overflow: 'hidden' }}>
-        <StyledChat/>
-      </Box>
+      {showChat && (
+        <Box sx={{ flexGrow: 1, minHeight: 0, overflow: 'hidden' }}>
+          <StyledChat/>
+        </Box>
+      )}
     </Box>
   );
 };

--- a/src/components/lessonDetail/WorkZone.tsx
+++ b/src/components/lessonDetail/WorkZone.tsx
@@ -14,7 +14,6 @@ import { useAuth } from '../../context/AuthContext';
 import { UseSyncedVideoResult } from '../../hooks/useSyncedVideo';
 import { UseSyncedGrammarResult } from '../../hooks/useSyncedGrammar';
 import GridViewIcon from '@mui/icons-material/GridView';
-import PresenterBar from './PresenterBar';
 import SyncedContentView from '../../features/lessonContent/student/SyncedContentView';
 import type { useSyncedContent } from '../../hooks/useSyncedContent';
 import { useQuery } from '@tanstack/react-query';
@@ -30,7 +29,7 @@ interface WorkZoneProps {
   useSyncedContent?: UseSyncedContentResult;
   onClose: () => void;
   lessonId: string;
-  room: Room;
+  room?: Room | null;
 }
 
 /**
@@ -198,6 +197,7 @@ const WorkZone: React.FC<WorkZoneProps> = ({useSyncedVideo, useSyncedGrammar, us
               {state.open && state.material && (
                 <SyncedVideoPlayer
                   useSyncedVideo={useSyncedVideo}
+                  showChat={!!room}
                 />
               )}
               {grammarState?.open && grammarState?.material && useSyncedGrammar && (
@@ -215,7 +215,7 @@ const WorkZone: React.FC<WorkZoneProps> = ({useSyncedVideo, useSyncedGrammar, us
                   contentId={useSyncedContent.state.contentId}
                   focusBlockId={useSyncedContent.state.focusBlockId}
                   locked={!!useSyncedContent.state.locked}
-                  contentSync={{ room, isTutor, contentId: useSyncedContent.state.contentId }}
+                  contentSync={room ? { room, isTutor, contentId: useSyncedContent.state.contentId } : undefined}
                 />
               </Box>
             </Box>


### PR DESCRIPTION
## Summary
- add the lesson workspace to the Daily video-call layout and expose an "Open materials" button for tutors
- reuse the existing WorkZone with optional LiveKit dependencies so teachers can browse materials without sync
- allow hiding the LiveKit chat inside the video player when the workspace is used outside LiveKit

## Testing
- `CI=1 npm run build -- --logLevel warn`


------
https://chatgpt.com/codex/tasks/task_e_68e218e8ee30832caa7760a7675d767a